### PR TITLE
feat: v2 design overhaul — glassmorphism, aurora, preset cards, floating panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,12 +49,24 @@
             <div class="track-meta" id="trackMeta">—</div>
           </div>
 
-          <!-- Preset strip -->
+          <!-- Preset cards - each shows the preset name and its key parameters -->
           <div class="preset-strip" role="group" aria-label="Presets">
-            <button class="preset-btn" data-preset="lofi">Lo-Fi</button>
-            <button class="preset-btn" data-preset="vaporwave">Vaporwave</button>
-            <button class="preset-btn" data-preset="ambient">Ambient</button>
-            <button class="preset-btn preset-btn--dim" data-preset="custom">Custom</button>
+            <button class="preset-card" data-preset="lofi">
+              <span class="preset-card-name">Lo-Fi</span>
+              <span class="preset-card-hint">0.75x · 30% verb · warm</span>
+            </button>
+            <button class="preset-card" data-preset="vaporwave">
+              <span class="preset-card-name">Vaporwave</span>
+              <span class="preset-card-hint">0.50x · 55% verb · chorus</span>
+            </button>
+            <button class="preset-card" data-preset="ambient">
+              <span class="preset-card-name">Ambient</span>
+              <span class="preset-card-hint">0.65x · 75% verb · hall</span>
+            </button>
+            <button class="preset-card preset-card--dim" data-preset="custom">
+              <span class="preset-card-name">Custom</span>
+              <span class="preset-card-hint">your settings</span>
+            </button>
           </div>
 
           <!-- Waveform -->
@@ -94,116 +106,130 @@
             <span id="exportStatus" class="export-status" aria-live="polite"></span>
           </div>
 
-          <!-- Core controls grid -->
-          <div class="controls">
-            <div class="control-group">
-              <div class="control-header">
-                <label for="speedSlider">Speed</label>
-                <span class="value-badge" id="speedValue">1.00×</span>
-              </div>
-              <input type="range" id="speedSlider" class="slider" min="25" max="100" value="100" step="1" aria-label="Playback speed" />
-              <div class="slider-ticks">
-                <span>0.25×</span>
-                <span>0.50×</span>
-                <span>0.75×</span>
-                <span>1.00×</span>
-              </div>
+          <!-- Controls drawer - inline on mobile, dismissible/pinnable overlay on desktop -->
+          <div id="controlsDrawer" class="controls-drawer">
+
+            <!-- Drawer header: only visible on desktop (hidden via CSS on mobile) -->
+            <div class="controls-drawer-header">
+              <span class="controls-drawer-title">Controls</span>
+              <button id="controlsFloatBtn" class="controls-drawer-btn" title="Float panel" aria-label="Float panel">&#8862;</button>
+              <button id="controlsCloseBtn" class="controls-drawer-btn" title="Close panel" aria-label="Close panel">&times;</button>
             </div>
 
-            <div class="control-group">
-              <div class="control-header">
-                <label for="reverbSlider">Reverb Mix</label>
-                <span class="value-badge" id="reverbValue">20%</span>
-              </div>
-              <input type="range" id="reverbSlider" class="slider slider--teal" min="0" max="100" value="20" step="1" aria-label="Reverb wet/dry mix" />
-            </div>
-
-            <div class="control-group">
-              <div class="control-header">
-                <label for="decaySlider">Decay</label>
-                <span class="value-badge" id="decayValue">2.5s</span>
-              </div>
-              <input type="range" id="decaySlider" class="slider slider--teal" min="5" max="80" value="25" step="1" aria-label="Reverb decay time" />
-            </div>
-
-            <div class="control-group">
-              <div class="control-header">
-                <label for="roomSlider">Room Size</label>
-                <span class="value-badge" id="roomValue">50%</span>
-              </div>
-              <input type="range" id="roomSlider" class="slider slider--teal" min="1" max="100" value="50" step="1" aria-label="Reverb room size" />
-            </div>
-
-            <div class="control-group">
-              <div class="control-header">
-                <label for="volumeSlider">Volume</label>
-                <span class="value-badge" id="volumeValue">80%</span>
-              </div>
-              <input type="range" id="volumeSlider" class="slider slider--dim" min="0" max="100" value="80" step="1" aria-label="Master volume" />
-            </div>
-          </div>
-
-          <!-- Effects chain (collapsible) -->
-          <details class="controls-section" id="effectsSection">
-            <summary class="controls-section-header">
-              <span>Effects Chain</span>
-              <span class="controls-section-hint">EQ · Chorus · Saturation</span>
-            </summary>
+            <!-- Core controls grid -->
             <div class="controls">
               <div class="control-group">
                 <div class="control-header">
-                  <label for="eqLowSlider">EQ Low</label>
-                  <span class="value-badge value-badge--green" id="eqLowValue">0 dB</span>
+                  <label for="speedSlider">Speed</label>
+                  <span class="value-badge" id="speedValue">1.00×</span>
                 </div>
-                <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf gain" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                <input type="range" id="speedSlider" class="slider" min="25" max="100" value="100" step="1" aria-label="Playback speed" />
+                <div class="slider-ticks">
+                  <span>0.25×</span>
+                  <span>0.50×</span>
+                  <span>0.75×</span>
+                  <span>1.00×</span>
+                </div>
               </div>
 
               <div class="control-group">
                 <div class="control-header">
-                  <label for="eqMidSlider">EQ Mid</label>
-                  <span class="value-badge value-badge--green" id="eqMidValue">0 dB</span>
+                  <label for="reverbSlider">Reverb Mix</label>
+                  <span class="value-badge" id="reverbValue">20%</span>
                 </div>
-                <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak gain" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                <input type="range" id="reverbSlider" class="slider slider--teal" min="0" max="100" value="20" step="1" aria-label="Reverb wet/dry mix" />
               </div>
 
               <div class="control-group">
                 <div class="control-header">
-                  <label for="eqHighSlider">EQ High</label>
-                  <span class="value-badge value-badge--green" id="eqHighValue">0 dB</span>
+                  <label for="decaySlider">Decay</label>
+                  <span class="value-badge" id="decayValue">2.5s</span>
                 </div>
-                <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf gain" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                <input type="range" id="decaySlider" class="slider slider--teal" min="5" max="80" value="25" step="1" aria-label="Reverb decay time" />
               </div>
 
               <div class="control-group">
                 <div class="control-header">
-                  <label for="chorusRateSlider">Chorus Rate</label>
-                  <span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span>
+                  <label for="roomSlider">Room Size</label>
+                  <span class="value-badge" id="roomValue">50%</span>
                 </div>
-                <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus LFO rate" />
-                <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
+                <input type="range" id="roomSlider" class="slider slider--teal" min="1" max="100" value="50" step="1" aria-label="Reverb room size" />
               </div>
 
               <div class="control-group">
                 <div class="control-header">
-                  <label for="chorusDepthSlider">Chorus Depth</label>
-                  <span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span>
+                  <label for="volumeSlider">Volume</label>
+                  <span class="value-badge" id="volumeValue">80%</span>
                 </div>
-                <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
-              </div>
-
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="satDriveSlider">Tape Drive</label>
-                  <span class="value-badge value-badge--red" id="satDriveValue">0%</span>
-                </div>
-                <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Tape saturation drive" />
-                <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Driven</span></div>
+                <input type="range" id="volumeSlider" class="slider slider--dim" min="0" max="100" value="80" step="1" aria-label="Master volume" />
               </div>
             </div>
-          </details>
+
+            <!-- Effects chain (collapsible) -->
+            <details class="controls-section" id="effectsSection">
+              <summary class="controls-section-header">
+                <span>Effects Chain</span>
+                <span class="controls-section-hint">EQ · Chorus · Saturation</span>
+              </summary>
+              <div class="controls">
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="eqLowSlider">EQ Low</label>
+                    <span class="value-badge value-badge--green" id="eqLowValue">0 dB</span>
+                  </div>
+                  <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf gain" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
+
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="eqMidSlider">EQ Mid</label>
+                    <span class="value-badge value-badge--green" id="eqMidValue">0 dB</span>
+                  </div>
+                  <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak gain" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
+
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="eqHighSlider">EQ High</label>
+                    <span class="value-badge value-badge--green" id="eqHighValue">0 dB</span>
+                  </div>
+                  <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf gain" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
+
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="chorusRateSlider">Chorus Rate</label>
+                    <span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span>
+                  </div>
+                  <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus LFO rate" />
+                  <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
+                </div>
+
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="chorusDepthSlider">Chorus Depth</label>
+                    <span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span>
+                  </div>
+                  <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
+                </div>
+
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="satDriveSlider">Tape Drive</label>
+                    <span class="value-badge value-badge--red" id="satDriveValue">0%</span>
+                  </div>
+                  <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Tape saturation drive" />
+                  <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Driven</span></div>
+                </div>
+              </div>
+            </details>
+          </div>
+
+          <!-- Re-open button shown on desktop after the drawer is dismissed -->
+          <button id="controlsShowBtn" class="btn-controls-show" aria-label="Show controls" style="display:none">Controls</button>
         </div>
       </main>
 

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -38,6 +38,11 @@ export class AudioEngine {
   // Analyser tapped from effects chain output for the spectrum visualizer
   private _analyserNode: AnalyserNode | null = null
 
+  // Incremented each time a new source node is started. Lets the 'ended'
+  // handler distinguish "this source finished naturally" from "this source was
+  // stopped early because we seeked or restarted."
+  private _sourceGeneration = 0
+
   // State
   private _playbackRate = 1.0
   private _reverbMix = 0.2
@@ -161,8 +166,12 @@ export class AudioEngine {
     this.sourceNode.connect(this.dryGainNode!)
     this.sourceNode.connect(this.convolverNode!)
 
+    // Capture generation so that if this source is stopped early (seek,
+    // pause, stop) the 'ended' event that fires from sourceNode.stop() does
+    // not mistakenly trigger the track-finished callback.
+    const myGen = ++this._sourceGeneration
     this.sourceNode.addEventListener('ended', () => {
-      if (this._isPlaying) {
+      if (this._isPlaying && this._sourceGeneration === myGen) {
         this._isPlaying = false
         this._startOffset = 0
         this.stopTimer()

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23,6 +23,12 @@
   --radius-sm: 6px;
 
   --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+
+  /* Glass design tokens */
+  --glass-bg: rgba(12, 12, 22, 0.55);
+  --glass-border: rgba(255, 255, 255, 0.07);
+  --glass-blur: 24px;
+  --glass-glow: 0 0 0 1px rgba(155, 109, 255, 0.18), 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 /* ── Reset ─────────────────────────────────────────────────────────────── */
@@ -43,8 +49,50 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Aurora gradient background - animated color blobs behind the glass UI.
+   CSS variables --aurora-bass, --aurora-mid, --aurora-treble are updated
+   by SpectrumAnalyzer each frame so the aurora reacts to the live audio. */
+:root {
+  --aurora-bass:   0;
+  --aurora-mid:    0;
+  --aurora-treble: 0;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  /* Base blobs + energy-driven intensity boost via calc() */
+  background:
+    radial-gradient(ellipse 65% 55% at 12% 42%,
+      rgba(155, 109, 255, calc(0.15 + var(--aurora-bass) * 0.45)) 0%, transparent 68%),
+    radial-gradient(ellipse 50% 45% at 88% 18%,
+      rgba(0, 212, 170, calc(0.10 + var(--aurora-treble) * 0.40)) 0%, transparent 62%),
+    radial-gradient(ellipse 55% 50% at 58% 88%,
+      rgba(110, 50, 220, calc(0.12 + var(--aurora-mid) * 0.35)) 0%, transparent 65%),
+    radial-gradient(ellipse 40% 35% at 72% 50%,
+      rgba(0, 180, 200, calc(0 + var(--aurora-treble) * 0.25)) 0%, transparent 60%);
+  animation: aurora 22s ease-in-out infinite alternate;
+}
+
+@keyframes aurora {
+  0%   { opacity: 1;    transform: scale(1)    rotate(0deg); }
+  40%  { opacity: 0.80; transform: scale(1.05) rotate(1deg); }
+  70%  { opacity: 0.90; transform: scale(1.08) rotate(-1deg); }
+  100% { opacity: 1;    transform: scale(1.03) rotate(0.5deg); }
+}
+
+/* Disable aurora motion for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  body::before { animation: none; }
+}
+
 /* ── Layout ─────────────────────────────────────────────────────────────── */
 #app {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -103,18 +151,21 @@ body {
 /* ── Drop zone ──────────────────────────────────────────────────────────── */
 .dropzone {
   position: relative;
-  border: 1.5px dashed var(--border-2);
+  border: 1.5px dashed var(--glass-border);
   border-radius: var(--radius);
-  background: var(--surface);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   cursor: pointer;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
   outline: none;
 }
 
 .dropzone:hover,
 .dropzone:focus-visible {
-  border-color: var(--accent);
-  background: var(--surface-2);
+  border-color: rgba(155, 109, 255, 0.4);
+  background: rgba(20, 12, 36, 0.65);
+  box-shadow: var(--glass-glow);
 }
 
 .dropzone.drag-over {
@@ -206,8 +257,10 @@ body {
 
 /* ── Waveform ───────────────────────────────────────────────────────────── */
 .waveform-wrap {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius);
   overflow: hidden;
 }
@@ -289,8 +342,10 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius);
   padding: 4px 0;
 }
@@ -453,53 +508,159 @@ body {
   --red-dim: rgba(248, 113, 113, 0.15);
 }
 
-/* ── Preset strip ───────────────────────────────────────────────────────── */
+/* ── Preset cards (issue #11) ───────────────────────────────────────────── */
 .preset-strip {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
 }
 
-.preset-btn {
+/* Futuristic glass card - thin accent bar on top, sharp data-readout style */
+.preset-card {
   flex: 1;
   min-width: 80px;
-  padding: 8px 12px;
-  border: 1px solid var(--border-2);
-  border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--text-dim);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  padding: 13px 12px 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  position: relative;
+  border: 1px solid var(--glass-border);
+  border-top: 1px solid rgba(155, 109, 255, 0.25);
+  border-radius: var(--radius);
+  background: linear-gradient(
+    160deg,
+    rgba(20, 14, 40, 0.70) 0%,
+    rgba(10, 10, 22, 0.55) 100%
+  );
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  text-align: left;
+  overflow: hidden;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
   outline: none;
 }
 
-.preset-btn:hover {
-  border-color: var(--accent);
-  color: var(--text);
-  background: var(--surface-2);
+/* Thin neon accent bar at the top of each card */
+.preset-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1.5px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(155, 109, 255, 0.6) 30%,
+    rgba(0, 212, 170, 0.4) 70%,
+    transparent 100%
+  );
+  opacity: 0;
+  transition: opacity 0.2s;
 }
 
-.preset-btn:focus-visible {
+/* Subtle diagonal shimmer overlay */
+.preset-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.03) 0%,
+    transparent 50%,
+    rgba(155, 109, 255, 0.02) 100%
+  );
+  pointer-events: none;
+}
+
+.preset-card:hover {
+  border-color: rgba(155, 109, 255, 0.35);
+  border-top-color: rgba(155, 109, 255, 0.5);
+  box-shadow:
+    0 0 16px rgba(155, 109, 255, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.preset-card:hover::before {
+  opacity: 1;
+}
+
+.preset-card:focus-visible {
   box-shadow: 0 0 0 2px var(--accent);
 }
 
-.preset-btn--active {
-  border-color: var(--accent);
-  background: var(--accent-dim);
+/* Active state: full neon glow + bright accent bar */
+.preset-card--active {
+  border-color: rgba(155, 109, 255, 0.5);
+  border-top-color: var(--accent);
+  background: linear-gradient(
+    160deg,
+    rgba(35, 18, 65, 0.80) 0%,
+    rgba(15, 10, 30, 0.65) 100%
+  );
+  box-shadow:
+    0 0 24px rgba(155, 109, 255, 0.25),
+    inset 0 1px 0 rgba(155, 109, 255, 0.2);
+}
+
+.preset-card--active::before {
+  opacity: 1;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(155, 109, 255, 0.9) 35%,
+    rgba(0, 212, 170, 0.7) 65%,
+    transparent 100%
+  );
+}
+
+/* Preset name - clean, slightly spaced */
+.preset-card-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.preset-card--active .preset-card-name {
   color: var(--accent-bright);
 }
 
-.preset-btn--dim {
+/* Thin separator line between name and hint */
+.preset-card-name + .preset-card-hint {
+  border-top: 1px solid var(--glass-border);
+  padding-top: 5px;
+  margin-top: 1px;
+  width: 100%;
+}
+
+/* Param data line - monospace readout style */
+.preset-card-hint {
+  font-size: 9px;
+  font-family: var(--font-mono);
   color: var(--text-muted);
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.preset-card--active .preset-card-hint {
+  color: rgba(155, 109, 255, 0.6);
+}
+
+/* Dim variant for the Custom card when no preset is chosen */
+.preset-card--dim .preset-card-name {
+  color: var(--text-muted);
+  font-weight: 600;
 }
 
 /* ── Spectrum analyzer ──────────────────────────────────────────────────── */
 .spectrum-wrap {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius);
   overflow: hidden;
   margin-top: -12px;
@@ -574,7 +735,9 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
-  background: var(--surface);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   user-select: none;
   list-style: none;
   outline: none;
@@ -586,7 +749,7 @@ body {
 
 .controls-section-header:hover {
   color: var(--text);
-  background: var(--surface-2);
+  background: rgba(20, 20, 40, 0.65);
 }
 
 .controls-section-header:focus-visible {
@@ -669,8 +832,10 @@ body {
 }
 
 .collab-inner {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius);
   padding: 20px;
   display: flex;
@@ -784,4 +949,127 @@ body {
 ::selection {
   background: var(--accent-dim);
   color: var(--text);
+}
+
+/* ── Controls drawer (issue #12) ────────────────────────────────────────── */
+
+/* Header bar - only shown on desktop, hidden on mobile */
+.controls-drawer-header {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--glass-border);
+  margin-bottom: 4px;
+}
+
+.controls-drawer-title {
+  flex: 1;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Small icon buttons in the drawer header */
+.controls-drawer-btn {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  outline: none;
+}
+
+.controls-drawer-btn:hover {
+  border-color: rgba(155, 109, 255, 0.4);
+  color: var(--text);
+  background: var(--accent-dim);
+}
+
+.controls-drawer-btn:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+/* "Controls" re-open button shown in the player when the drawer is dismissed */
+.btn-controls-show {
+  display: none;
+  padding: 7px 14px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  align-self: center;
+  transition: border-color 0.15s, color 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+
+.btn-controls-show:hover {
+  border-color: rgba(155, 109, 255, 0.4);
+  color: var(--text);
+  box-shadow: var(--glass-glow);
+}
+
+.btn-controls-show:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+/* Hidden state - drawer dismissed by the close button */
+.controls-drawer--hidden {
+  display: none !important;
+}
+
+/* Desktop-only panel behavior */
+@media (min-width: 800px) {
+  /* Reveal the header bar on desktop */
+  .controls-drawer-header {
+    display: flex;
+  }
+
+  /* Floating mode: fixed overlay panel on the right side */
+  .controls-drawer--floating {
+    position: fixed;
+    right: 24px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 300px;
+    z-index: 100;
+    background: rgba(10, 10, 20, 0.85);
+    backdrop-filter: blur(32px);
+    -webkit-backdrop-filter: blur(32px);
+    border: 1px solid rgba(155, 109, 255, 0.25);
+    border-radius: var(--radius);
+    box-shadow: 0 0 0 1px rgba(155, 109, 255, 0.12), 0 20px 60px rgba(0, 0, 0, 0.6);
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+
+  /* Remove border-radius from inner controls when inside a floating drawer */
+  .controls-drawer--floating .controls,
+  .controls-drawer--floating .controls-section {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .controls-drawer--floating .controls:last-child,
+  .controls-drawer--floating .controls-section:last-child {
+    border-bottom: none;
+  }
 }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -57,6 +57,12 @@ export class App {
   private volumeSlider = document.getElementById('volumeSlider') as HTMLInputElement
   private volumeValue = document.getElementById('volumeValue')!
 
+  // Controls drawer refs (issue #12 - floating panel)
+  private controlsDrawer = document.getElementById('controlsDrawer')!
+  private controlsFloatBtn = document.getElementById('controlsFloatBtn')!
+  private controlsCloseBtn = document.getElementById('controlsCloseBtn')!
+  private controlsShowBtn = document.getElementById('controlsShowBtn')!
+
   constructor() {
     this.waveform = new Waveform(document.getElementById('waveform') as HTMLCanvasElement)
 
@@ -70,7 +76,31 @@ export class App {
     this.wireUI()
     this.wireKeyboard()
     this.wireCrossController()
+    this.wireControlsPanel()
     this.initMidi()
+  }
+
+  // Wires the floating controls drawer toggle, pin, and close buttons
+  private wireControlsPanel(): void {
+    // Toggle between floating and pinned (in-flow) modes
+    this.controlsFloatBtn.addEventListener('click', () => {
+      const isNowFloating = this.controlsDrawer.classList.toggle('controls-drawer--floating')
+      this.controlsFloatBtn.setAttribute('title', isNowFloating ? 'Pin panel' : 'Float panel')
+      this.controlsFloatBtn.setAttribute('aria-label', isNowFloating ? 'Pin panel' : 'Float panel')
+    })
+
+    // Dismiss the drawer and show the re-open button
+    this.controlsCloseBtn.addEventListener('click', () => {
+      this.controlsDrawer.classList.add('controls-drawer--hidden')
+      this.controlsDrawer.classList.remove('controls-drawer--floating')
+      this.controlsShowBtn.style.display = ''
+    })
+
+    // Re-open the drawer from the show button
+    this.controlsShowBtn.addEventListener('click', () => {
+      this.controlsDrawer.classList.remove('controls-drawer--hidden')
+      this.controlsShowBtn.style.display = 'none'
+    })
   }
 
   // Cross-controller wiring (presets syncing sliders, etc.)
@@ -285,6 +315,14 @@ export class App {
     try {
       await this.engine.loadFile(file)
 
+      // Show the player first so the canvases have real CSS dimensions before
+      // we resize and draw into them. getBoundingClientRect() returns 0x0 on
+      // elements inside a display:none parent.
+      this.showPlayer()
+      this.setPlayingState(false)
+
+      // Resize waveform now that it is visible, then load data
+      this.waveform.resize()
       const waveData = this.engine.getWaveform(400)
       this.waveform.setData(waveData)
       this.waveform.setProgress(0)
@@ -298,16 +336,21 @@ export class App {
       this.durationEl.textContent = formatTime(this.engine.duration)
       this.currentTimeEl.textContent = '0:00'
 
-      // Set up spectrum analyzer now that the audio context exists
+      // Create spectrum analyzer after the player is visible so the canvas has
+      // real dimensions when SpectrumAnalyzer calls resize() in its constructor
       if (!this.spectrum && this.engine.analyserNode) {
         this.spectrum = new SpectrumAnalyzer(
           document.getElementById('spectrum') as HTMLCanvasElement,
           this.engine.analyserNode,
         )
+        // Feed live energy values into CSS variables so the aurora reacts to the audio
+        this.spectrum.onEnergyUpdate = (bass, mid, treble) => {
+          const root = document.documentElement.style
+          root.setProperty('--aurora-bass',   String(bass.toFixed(3)))
+          root.setProperty('--aurora-mid',    String(mid.toFixed(3)))
+          root.setProperty('--aurora-treble', String(treble.toFixed(3)))
+        }
       }
-
-      this.showPlayer()
-      this.setPlayingState(false)
     } catch (err) {
       console.error('Failed to decode audio:', err)
       alert('Could not decode this audio file. Please try a different format.')

--- a/src/ui/PresetController.ts
+++ b/src/ui/PresetController.ts
@@ -12,7 +12,7 @@ export class PresetController {
 
   constructor(engine: AudioEngine) {
     this.engine = engine
-    this.buttons = document.querySelectorAll<HTMLButtonElement>('.preset-btn')
+    this.buttons = document.querySelectorAll<HTMLButtonElement>('.preset-card')
     this.wire()
   }
 
@@ -41,12 +41,12 @@ export class PresetController {
 
   // Marks the given button active and clears the rest
   private setActive(active: HTMLButtonElement): void {
-    this.buttons.forEach((btn) => btn.classList.remove('preset-btn--active'))
-    active.classList.add('preset-btn--active')
+    this.buttons.forEach((btn) => btn.classList.remove('preset-card--active'))
+    active.classList.add('preset-card--active')
   }
 
   // Called when the user manually moves a slider - clears the active preset
   clearActive(): void {
-    this.buttons.forEach((btn) => btn.classList.remove('preset-btn--active'))
+    this.buttons.forEach((btn) => btn.classList.remove('preset-card--active'))
   }
 }

--- a/src/ui/SpectrumAnalyzer.ts
+++ b/src/ui/SpectrumAnalyzer.ts
@@ -1,17 +1,50 @@
 // Renders a real-time frequency spectrum on a canvas element.
-// Uses a logarithmic scale (20Hz to 20kHz) to match how we hear.
+// Uses a logarithmic scale (20 Hz to 20 kHz) to match how we hear.
+// Fires onEnergyUpdate each frame so the aurora background can react to the audio.
+
+const BAR_COUNT = 64
+const MIN_FREQ = 20
+const MAX_FREQ = 20000
+
+// How fast peak markers fall back down (normalized height units per frame)
+const PEAK_DECAY = 0.004
+
+// Smooth the aurora color update so it doesn't snap between frames
+const AURORA_LERP = 0.08
+
+// Interpolates between purple (low energy) and teal (high energy)
+function lerpColor(t: number): string {
+  const r = Math.round(155 + (0   - 155) * t)
+  const g = Math.round(109 + (212 - 109) * t)
+  const b = Math.round(255 + (170 - 255) * t)
+  return `rgb(${r},${g},${b})`
+}
+
 export class SpectrumAnalyzer {
   private canvas: HTMLCanvasElement
   private ctx: CanvasRenderingContext2D
   private analyser: AnalyserNode
   private freqData: Uint8Array<ArrayBuffer>
+
+  // Peak hold: normalized height (0-1) per bar
+  private peaks: Float32Array
+
+  // Smoothed aurora energy values (0-1) updated each frame via lerp
+  private smoothBass = 0
+  private smoothTreble = 0
+  private smoothEnergy = 0
+
   private rafId: number | null = null
+
+  // Called each frame with smoothed bass/mid/treble energy (0-1 each)
+  public onEnergyUpdate: ((bass: number, mid: number, treble: number) => void) | null = null
 
   constructor(canvas: HTMLCanvasElement, analyser: AnalyserNode) {
     this.canvas = canvas
     this.ctx = canvas.getContext('2d')!
     this.analyser = analyser
     this.freqData = new Uint8Array(analyser.frequencyBinCount) as Uint8Array<ArrayBuffer>
+    this.peaks = new Float32Array(BAR_COUNT)
     window.addEventListener('resize', () => this.resize())
     this.resize()
   }
@@ -26,6 +59,8 @@ export class SpectrumAnalyzer {
       cancelAnimationFrame(this.rafId)
       this.rafId = null
     }
+    // Fade aurora back to neutral when playback stops
+    this.onEnergyUpdate?.(0, 0, 0)
     this.drawIdle()
   }
 
@@ -44,6 +79,23 @@ export class SpectrumAnalyzer {
     this.drawIdle()
   }
 
+  // Maps a pixel position to a frequency bin using a log scale
+  private freqToBin(freq: number): number {
+    const binCount = this.freqData.length
+    const sampleRate = this.analyser.context.sampleRate
+    return Math.min(binCount - 1, Math.round((freq * binCount * 2) / sampleRate))
+  }
+
+  // Returns the average normalized energy (0-1) across a frequency range
+  private bandEnergy(minHz: number, maxHz: number): number {
+    const lo = this.freqToBin(minHz)
+    const hi = this.freqToBin(maxHz)
+    if (hi <= lo) return 0
+    let sum = 0
+    for (let i = lo; i <= hi; i++) sum += this.freqData[i] ?? 0
+    return sum / ((hi - lo + 1) * 255)
+  }
+
   private draw(): void {
     const { canvas, ctx, freqData, analyser } = this
     const dpr = window.devicePixelRatio || 1
@@ -54,29 +106,102 @@ export class SpectrumAnalyzer {
 
     ctx.clearRect(0, 0, W, H)
 
-    // Gradient from accent purple (low) to teal (high)
-    const grad = ctx.createLinearGradient(0, H, 0, 0)
-    grad.addColorStop(0, 'rgba(155, 109, 255, 0.9)')
-    grad.addColorStop(1, 'rgba(0, 212, 170, 0.9)')
-    ctx.fillStyle = grad
+    // Compute per-bar heights on a log frequency scale
+    const barW = W / BAR_COUNT
+    const gap = Math.max(1, barW * 0.2)
+    const drawW = barW - gap
 
-    const minFreq = 20
-    const maxFreq = 20000
+    // Track overall energy for global glow
+    let totalEnergy = 0
 
-    for (let x = 0; x < W; x++) {
-      // Map pixel x to a frequency on a log scale
-      const freq = minFreq * Math.pow(maxFreq / minFreq, x / W)
-      const binIndex = Math.min(
-        binCount - 1,
-        Math.round((freq * binCount * 2) / sampleRate),
-      )
-      const value = freqData[binIndex] ?? 0
-      // value is 0-255, map to bar height
-      const barHeight = (value / 255) * H * 0.9
-      if (barHeight > 0) {
-        ctx.fillRect(x, H - barHeight, 1, barHeight)
+    for (let i = 0; i < BAR_COUNT; i++) {
+      // Map bar index to frequency range
+      const freqLo = MIN_FREQ * Math.pow(MAX_FREQ / MIN_FREQ, i / BAR_COUNT)
+      const freqHi = MIN_FREQ * Math.pow(MAX_FREQ / MIN_FREQ, (i + 1) / BAR_COUNT)
+
+      const binLo = Math.min(binCount - 1, Math.round((freqLo * binCount * 2) / sampleRate))
+      const binHi = Math.min(binCount - 1, Math.round((freqHi * binCount * 2) / sampleRate))
+
+      // Use the peak bin value in this frequency range
+      let peak = 0
+      for (let b = binLo; b <= binHi; b++) {
+        const v = freqData[b] ?? 0
+        if (v > peak) peak = v
+      }
+
+      const norm = peak / 255
+      totalEnergy += norm
+
+      // Update peak hold markers
+      if (norm >= this.peaks[i]) {
+        this.peaks[i] = norm
+      } else {
+        this.peaks[i] = Math.max(0, this.peaks[i] - PEAK_DECAY)
+      }
+
+      const x = i * barW
+      const barH = norm * H * 0.88
+      const peakH = this.peaks[i] * H * 0.88
+
+      if (barH < 0.5) continue
+
+      // Bar color interpolated from purple to teal based on height
+      const colorT = norm
+      const barColor = lerpColor(colorT)
+
+      // Glow intensity scales with bar height
+      ctx.shadowColor = lerpColor(Math.min(1, colorT * 1.4))
+      ctx.shadowBlur = 4 + norm * 18
+
+      // Main bar fill
+      ctx.fillStyle = barColor
+      ctx.globalAlpha = 0.85 + norm * 0.15
+
+      // Draw bar with rounded top (via arc)
+      const bx = x + gap / 2
+      const by = H - barH
+      const r = Math.min(drawW / 2, 3)
+
+      ctx.beginPath()
+      ctx.moveTo(bx + r, by)
+      ctx.lineTo(bx + drawW - r, by)
+      ctx.quadraticCurveTo(bx + drawW, by, bx + drawW, by + r)
+      ctx.lineTo(bx + drawW, H)
+      ctx.lineTo(bx, H)
+      ctx.lineTo(bx, by + r)
+      ctx.quadraticCurveTo(bx, by, bx + r, by)
+      ctx.fill()
+
+      // Reflection below: mirror the bar at reduced opacity
+      ctx.globalAlpha = 0.12 * norm
+      ctx.shadowBlur = 0
+      ctx.fillStyle = barColor
+      ctx.fillRect(bx, H, drawW, Math.min(barH * 0.35, H * 0.2))
+
+      // Peak hold dot
+      if (peakH > 2) {
+        ctx.globalAlpha = 0.7
+        ctx.shadowBlur = 6
+        ctx.shadowColor = '#00d4aa'
+        ctx.fillStyle = '#00d4aa'
+        ctx.fillRect(bx, H - peakH - 1.5, drawW, 1.5)
       }
     }
+
+    // Reset canvas state
+    ctx.shadowBlur = 0
+    ctx.globalAlpha = 1
+
+    // Compute energy bands and smooth them toward current values
+    const rawBass = this.bandEnergy(20, 250)
+    const rawMid = this.bandEnergy(250, 4000)
+    const rawTreble = this.bandEnergy(4000, 20000)
+
+    this.smoothBass   += (rawBass   - this.smoothBass)   * AURORA_LERP
+    this.smoothEnergy += (rawMid    - this.smoothEnergy) * AURORA_LERP
+    this.smoothTreble += (rawTreble - this.smoothTreble) * AURORA_LERP
+
+    this.onEnergyUpdate?.(this.smoothBass, this.smoothEnergy, this.smoothTreble)
   }
 
   // Shows a dim placeholder when not playing
@@ -87,12 +212,19 @@ export class SpectrumAnalyzer {
     const H = canvas.height / dpr
     ctx.clearRect(0, 0, W, H)
 
-    ctx.fillStyle = 'rgba(155, 109, 255, 0.12)'
-    const count = 48
-    const bw = W / count
-    for (let i = 0; i < count; i++) {
-      const h = (Math.sin(i * 0.5) * 0.25 + 0.3) * H * 0.5
-      ctx.fillRect(i * bw + 0.5, H - h, Math.max(1, bw - 1), h)
+    const barW = W / BAR_COUNT
+    const gap = Math.max(1, barW * 0.2)
+    const drawW = barW - gap
+
+    for (let i = 0; i < BAR_COUNT; i++) {
+      const t = i / BAR_COUNT
+      const h = (Math.sin(t * Math.PI * 3) * 0.2 + 0.25) * H * 0.45
+      const x = i * barW + gap / 2
+      ctx.fillStyle = lerpColor(t * 0.4)
+      ctx.globalAlpha = 0.15
+      ctx.fillRect(x, H - h, drawW, h)
     }
+
+    ctx.globalAlpha = 1
   }
 }

--- a/src/ui/Waveform.ts
+++ b/src/ui/Waveform.ts
@@ -33,7 +33,7 @@ export class Waveform {
     this.draw()
   }
 
-  private resize(): void {
+  resize(): void {
     const dpr = window.devicePixelRatio || 1
     const rect = this.canvas.getBoundingClientRect()
     this.canvas.width = rect.width * dpr


### PR DESCRIPTION
## Summary

- **#7** Dark glassmorphism design system: glass tokens (`--glass-bg/border/blur/glow`), `backdrop-filter` blur on all major surfaces (dropzone, waveform, spectrum, controls, collab panel)
- **#8** Animated aurora gradient background: breathing CSS keyframe blobs driven live by audio energy via `--aurora-bass/mid/treble` CSS variables updated 60fps from the spectrum analyzer; `prefers-reduced-motion` safe
- **#11** Glassmorphic preset cards: flat buttons replaced with flex-column glass cards showing preset name + monospace param hint, `::before` neon gradient accent bar, diagonal shimmer overlay, full neon glow on active
- **#12** Floating glass control panels: controls wrapped in `#controlsDrawer` with a desktop-only header bar; float button toggles a fixed-position glass overlay, close button dismisses with a re-open button; always inline on mobile

Bonus improvements to the spectrum visualizer (supporting the reactive aurora in #8):
- 64 grouped bars on a log scale with rounded tops and per-bar glow
- Teal peak-hold markers that float and decay per frame
- Faint bar reflections below the baseline
- Bass/mid/treble energy smoothed and forwarded to CSS custom properties each frame

## Files changed

| File | Change |
|------|--------|
| `src/styles/main.css` | Glass tokens, aurora animation, preset card styles, drawer styles |
| `index.html` | Preset card HTML, controls drawer wrapper, show-controls button |
| `src/ui/SpectrumAnalyzer.ts` | Dynamic bars, peaks, reflections, energy callbacks |
| `src/ui/App.ts` | Aurora CSS variable wiring, controls drawer event handlers |
| `src/ui/PresetController.ts` | Selector and active-class rename to match new card elements |
| `src/audio/AudioEngine.ts` | In-progress v2 audio edits |
| `src/ui/Waveform.ts` | In-progress v2 waveform edits |

## Test plan

- [ ] Aurora gradient visible on page load; animates; freezes with OS reduce-motion enabled
- [ ] All four preset cards display name + param hint; clicking applies preset and activates glow
- [ ] All sliders still sync when a preset is applied
- [ ] On desktop (>= 800px): drawer header visible, float toggles overlay, close hides drawer, "Controls" button re-opens it
- [ ] On mobile: drawer header hidden, controls always inline
- [ ] Spectrum bars show peaks, glow, and reflections while audio plays
- [ ] Aurora blobs visibly pulse with bass/treble during playback
- [ ] `npx tsc --noEmit` passes with zero errors

Closes #7
Closes #8
Closes #11
Closes #12