### PR TITLE
fix: clamp speed slider to 0.50x–1.70x, close #20

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,9 +94,9 @@
                   <label for="speedSlider">Speed</label>
                   <span class="value-badge" id="speedValue">1.00×</span>
                 </div>
-                <input type="range" id="speedSlider" class="slider" min="25" max="200" value="100" step="1" aria-label="Playback speed" />
+                <input type="range" id="speedSlider" class="slider" min="50" max="170" value="100" step="1" aria-label="Playback speed" />
                 <div class="slider-ticks">
-                  <span>0.25×</span><span>1.00×</span><span>2.00×</span>
+                  <span>0.50×</span><span>1.00×</span><span>1.70×</span>
                 </div>
               </div>
               <div class="control-group">

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -226,7 +226,7 @@ export class AudioEngine {
   // Parameter setters
 
   setPlaybackRate(rate: number): void {
-    const clamped = Math.max(0.25, Math.min(2.0, rate))
+    const clamped = Math.max(0.50, Math.min(1.70, rate))
     if (this._isPlaying && this.sourceNode && this.context) {
       const pos = this.currentTime
       this._startOffset = pos

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -171,7 +171,7 @@ export class App {
       this.notifyParamChange()
     })
     this.midi.bindCC(74, (v) => {
-      const rate = 0.25 + v * 1.75
+      const rate = 0.50 + v * 1.20
       this.engine.setPlaybackRate(rate)
       this.speedSlider.value = String(Math.round(rate * 100))
       this.speedValue.textContent = `${rate.toFixed(2)}x`


### PR DESCRIPTION
## Summary

- Speed slider range tightened to **0.50×–1.70×** (was 0.25×–2.00×) for a more musical and controlled feel
- HTML `min`/`max` attributes and tick labels updated to match
- `AudioEngine.setPlaybackRate()` clamp updated to `[0.50, 1.70]`
- MIDI CC 74 sweep remapped to cover the new range (`0.50 + v * 1.20`)

Also closes #20 — the Hyperpop preset was already shipped in v2 with the following profile: 1.15× speed, tight reverb (0.8s decay, small room), 55% tape saturation, maxed chorus (rate 4.0, depth 0.70), and a bright EQ (+6 high, +2 sub). The 1.15× rate sits comfortably within the new slider range.

## Test plan

- [ ] Drag speed slider — confirm it stops at 0.50× (left) and 1.70× (right)
- [ ] Apply Hyperpop preset — slider lands at ~1.15×, no clamping
- [ ] MIDI CC 74 sweep covers full 0.50×–1.70× range
- [ ] `npm run build` passes with no TypeScript errors

Closes #20