### PR TITLE
feat: BPM detection under song title, updates with speed — closes #13

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
           <div class="player-top">
             <div class="track-info">
               <div class="track-name" id="trackName">—</div>
+              <div class="track-bpm" id="trackBpm"></div>
               <div class="track-meta" id="trackMeta">—</div>
             </div>
             <div class="preset-strip" role="group" aria-label="Presets">

--- a/src/audio/BpmDetector.ts
+++ b/src/audio/BpmDetector.ts
@@ -1,0 +1,67 @@
+// Energy-based autocorrelation BPM detector.
+// Analyses the raw audio buffer once on load — no streaming required.
+// Returns the detected BPM (40–200 range), or 0 if detection fails.
+export function detectBpm(buffer: AudioBuffer): number {
+  const srcRate = buffer.sampleRate
+
+  // Mix down to mono
+  const ch0 = buffer.getChannelData(0)
+  const ch1 = buffer.numberOfChannels > 1 ? buffer.getChannelData(1) : null
+  const mono = ch1
+    ? Float32Array.from({ length: ch0.length }, (_, i) => (ch0[i] + ch1[i]) * 0.5)
+    : ch0
+
+  // Downsample to ~11 kHz to keep autocorrelation fast
+  const targetRate = 11025
+  const step = Math.max(1, Math.round(srcRate / targetRate))
+  const dsLen = Math.floor(mono.length / step)
+  const ds = new Float32Array(dsLen)
+  for (let i = 0; i < dsLen; i++) ds[i] = mono[i * step]
+  const dsRate = srcRate / step
+
+  // Compute RMS energy in 10 ms frames
+  const frameSize = Math.round(dsRate * 0.01)
+  const numFrames = Math.floor(dsLen / frameSize)
+  if (numFrames < 20) return 0
+
+  const energy = new Float32Array(numFrames)
+  for (let f = 0; f < numFrames; f++) {
+    let sum = 0
+    const base = f * frameSize
+    for (let i = 0; i < frameSize; i++) {
+      const s = ds[base + i]
+      sum += s * s
+    }
+    energy[f] = Math.sqrt(sum / frameSize)
+  }
+
+  // Check the track isn't silence
+  let maxE = 0
+  for (let f = 0; f < numFrames; f++) if (energy[f] > maxE) maxE = energy[f]
+  if (maxE < 1e-4) return 0
+
+  // Half-wave rectified energy derivative — onset strength signal
+  const onset = new Float32Array(numFrames)
+  for (let f = 1; f < numFrames; f++) {
+    const diff = energy[f] - energy[f - 1]
+    onset[f] = diff > 0 ? diff : 0
+  }
+
+  // Lag range for 40–200 BPM in frames (at 10 ms per frame)
+  // BPM = 60 / (lag * 0.01)  →  lag = 60 / (BPM * 0.01)
+  const lagMin = Math.round(60 / (200 * 0.01))  // ~30 frames
+  const lagMax = Math.round(60 / (40 * 0.01))   // ~150 frames
+
+  // Autocorrelate onset signal over the tempo lag range
+  let bestLag = lagMin
+  let bestCorr = -Infinity
+  for (let lag = lagMin; lag <= lagMax; lag++) {
+    let corr = 0
+    const limit = numFrames - lag
+    for (let f = 0; f < limit; f++) corr += onset[f] * onset[f + lag]
+    if (corr > bestCorr) { bestCorr = corr; bestLag = lag }
+  }
+
+  const bpm = 60 / (bestLag * 0.01)
+  return Math.round(bpm)
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -437,6 +437,14 @@ body.is-playing #iconPause    { opacity: 1; }
   text-overflow: ellipsis;
 }
 
+.track-bpm {
+  font-size: 11px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 /* ── Waveform ───────────────────────────────────────────────────────────── */
 .waveform-wrap {
   background: var(--glass-bg);

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1,4 +1,5 @@
 import { AudioEngine } from '../audio/AudioEngine'
+import { detectBpm } from '../audio/BpmDetector'
 import { Waveform } from './Waveform'
 import { AnomalySphere } from './AnomalySphere'
 import { StarOverlay } from './StarOverlay'
@@ -40,7 +41,10 @@ export class App {
   private fileInput = document.getElementById('fileInput') as HTMLInputElement
   private player = document.getElementById('player')!
   private trackName = document.getElementById('trackName')!
+  private trackBpm  = document.getElementById('trackBpm')!
   private trackMeta = document.getElementById('trackMeta')!
+
+  private _baseBpm = 0
   private currentTimeEl = document.getElementById('currentTime')!
   private durationEl = document.getElementById('duration')!
   private playPauseBtn = document.getElementById('playPauseBtn')!
@@ -177,6 +181,7 @@ export class App {
       this.speedValue.textContent = `${rate.toFixed(2)}x`
       this.sphere?.setSpeed(rate)
       this.presets.clearActive()
+      this.updateBpmDisplay()
       this.notifyParamChange()
     })
     this.midi.bindCC(91, (v) => {
@@ -255,6 +260,7 @@ export class App {
       this.speedValue.textContent = `${rate.toFixed(2)}x`
       this.sphere?.setSpeed(rate)
       this.presets.clearActive()
+      this.updateBpmDisplay()
       this.notifyParamChange()
     })
 
@@ -403,6 +409,9 @@ export class App {
       this.trackName.textContent = baseName
       this.exporter.trackName = baseName
 
+      this._baseBpm = detectBpm(this.engine.getBuffer()!)
+      this.updateBpmDisplay()
+
       this.trackMeta.textContent = `${formatTime(this.engine.duration)} · ${formatBytes(file.size)} · ${file.type || 'audio'}`
       this.durationEl.textContent = formatTime(this.engine.duration)
       this.currentTimeEl.textContent = '0:00'
@@ -437,6 +446,7 @@ export class App {
   private syncSlidersToParams(params: AudioParams): void {
     this.speedSlider.value = String(Math.round(params.playbackRate * 100))
     this.speedValue.textContent = `${params.playbackRate.toFixed(2)}x`
+    this.updateBpmDisplay()
 
     this.reverbSlider.value = String(Math.round(params.reverbMix * 100))
     this.reverbValue.textContent = `${Math.round(params.reverbMix * 100)}%`
@@ -451,6 +461,12 @@ export class App {
     this.volumeValue.textContent = `${Math.round(params.volume * 100)}%`
 
     this.notifyParamChange()
+  }
+
+  private updateBpmDisplay(): void {
+    if (!this._baseBpm) { this.trackBpm.textContent = ''; return }
+    const displayed = Math.round(this._baseBpm * this.engine.getParams().playbackRate)
+    this.trackBpm.textContent = `${displayed} BPM`
   }
 
   private togglePlayPause(): void {


### PR DESCRIPTION
## Summary

- Adds `BpmDetector.ts` — pure function using energy autocorrelation to detect BPM from the loaded audio buffer (40–200 BPM range, zero new dependencies)
- Displays detected BPM in the player HUD directly under the song title in accent purple (`128 BPM`)
- BPM display rescales in real time when speed changes via slider, MIDI CC 74, or preset

## How it works

1. Audio buffer mixed to mono and downsampled to ~11 kHz
2. RMS energy computed in 10 ms frames
3. Half-wave rectified energy derivative creates an onset strength signal
4. Autocorrelation across lag range for 40–200 BPM finds the dominant period
5. Displayed BPM = `detectedBpm × playbackRate` so it stays accurate at any speed

## Test plan

- [ ] Load a track — BPM appears under the song title (e.g. `128 BPM`)
- [ ] Drag speed slider — BPM updates in real time
- [ ] Apply a preset — BPM updates to match preset speed
- [ ] Load a near-silent or ambient file — BPM element is empty, no broken UI
- [ ] `npm run build` passes with no TypeScript errors

Closes #13