### PR TITLE
feat: styled transport control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
               <span class="time-current" id="currentTime">0:00</span>
               <div class="transport">
                 <button id="stopBtn" class="btn btn-icon" title="Stop (s)" aria-label="Stop">
-                  <svg width="16" height="16" viewBox="0 0 16 16"><rect x="3" y="3" width="10" height="10" fill="currentColor" rx="1"/></svg>
+                  <svg width="16" height="16" viewBox="0 0 16 16"><rect x="3" y="3" width="10" height="10" fill="currentColor" rx="3"/></svg>
                 </button>
                 <button id="playPauseBtn" class="btn btn-play" title="Play / Pause (Space)" aria-label="Play">
                   <svg id="iconPlay" width="22" height="22" viewBox="0 0 22 22"><polygon points="6,3 19,11 6,19" fill="currentColor"/></svg>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -125,6 +125,7 @@ body::after {
 /* Disable aurora motion for users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
   body::before, body::after { animation: none; }
+  .btn-play::before { animation: none !important; }
 }
 
 /* ── Layout ─────────────────────────────────────────────────────────────── */
@@ -486,13 +487,14 @@ body.is-playing #iconPause    { opacity: 1; }
 }
 
 .btn:focus-visible {
-  box-shadow: 0 0 0 2px var(--accent);
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
 }
 
 .btn-icon {
   width: 40px;
   height: 40px;
   border: 1px solid var(--border);
+  transition: background 0.15s, color 0.15s, box-shadow 0.2s, border-color 0.15s, transform 0.12s;
 }
 
 .btn-icon:hover {
@@ -513,17 +515,67 @@ body.is-playing #iconPause    { opacity: 1; }
 }
 
 body.is-playing .btn-play {
-  box-shadow: 0 4px 32px var(--accent-glow), 0 0 18px rgba(155, 109, 255, 0.45);
+  box-shadow: 0 4px 32px var(--accent-glow), 0 0 18px var(--accent-dim);
 }
 
 .btn-play:hover {
   background: var(--accent-bright);
-  box-shadow: 0 4px 28px rgba(155, 109, 255, 0.55);
+  box-shadow: 0 4px 28px var(--accent-glow);
   transform: scale(1.04);
 }
 
 .btn-play:active {
   transform: scale(0.97);
+}
+
+/* Pulsing halo ring while playing */
+@keyframes pulse-ring {
+  0%   { transform: translate(-50%, -50%) scale(1);    opacity: 0.55; }
+  65%  { transform: translate(-50%, -50%) scale(1.32); opacity: 0; }
+  100% { transform: translate(-50%, -50%) scale(1.32); opacity: 0; }
+}
+
+.btn-play::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid var(--accent);
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.is-playing .btn-play::before {
+  animation: pulse-ring 1.8s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+}
+
+/* Stop button — teal identity */
+#stopBtn:hover {
+  background: var(--teal-dim);
+  color: var(--teal);
+  border-color: var(--teal);
+  box-shadow: 0 0 10px var(--teal-dim);
+}
+
+#stopBtn:active {
+  transform: scale(0.93);
+  box-shadow: 0 0 14px var(--teal-dim);
+}
+
+/* Rewind button — accent identity */
+#rewindBtn:hover {
+  background: var(--accent-faint);
+  color: var(--accent-bright);
+  border-color: var(--accent-dim);
+  box-shadow: 0 0 10px var(--accent-dim);
+}
+
+#rewindBtn:active {
+  transform: scale(0.93) rotate(-15deg);
 }
 
 /* ── Controls ───────────────────────────────────────────────────────────── */
@@ -687,6 +739,12 @@ body.is-playing .btn-play {
   .btn-play {
     width: 50px;
     height: 50px;
+  }
+
+  /* 44×44 min touch targets on touch devices */
+  .btn-icon {
+    width: 44px;
+    height: 44px;
   }
 
   /* Drawers: full-width at bottom of phones */


### PR DESCRIPTION
## Summary
- Play button gets a pulsing halo ring animation while playing, with glow colors now using CSS variables (works across all 6 themes)
- Stop button gets a teal glow/color shift on hover; rewind gets an accent glow with a rotation on press
- Double-ring focus indicator for better accessibility visibility
- Touch targets enlarged to 44px on mobile; pulse ring disabled under `prefers-reduced-motion`

Closes #27

## Test plan
- [ ] Upload a file and verify play button pulses a ring while playing, stops when paused
- [ ] Hover stop — teal glow; hover rewind — accent glow
- [ ] Switch all 6 themes — glows match the theme accent color
- [ ] Tab through buttons — double-ring focus outline is visible
- [ ] Mobile/touch emulation — stop/rewind tap targets are at least 44×44px
- [ ] Keyboard: Space/S/Left arrow still trigger correct actions