### PR TITLE
feat: separate controls/effects drawers, add Hz resonance effect (#21)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,43 +130,83 @@
               </div>
             </div>
 
-            <details class="controls-section" id="effectsSection">
-              <summary class="controls-section-header">
-                <span>Effects Chain</span>
-                <span class="controls-section-hint">EQ · Chorus · Saturation</span>
-              </summary>
-              <div class="controls">
-                <div class="control-group">
-                  <div class="control-header"><label for="eqLowSlider">EQ Low</label><span class="value-badge value-badge--green" id="eqLowValue">0 dB</span></div>
-                  <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf" />
-                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="eqMidSlider">EQ Mid</label><span class="value-badge value-badge--green" id="eqMidValue">0 dB</span></div>
-                  <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak" />
-                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="eqHighSlider">EQ High</label><span class="value-badge value-badge--green" id="eqHighValue">0 dB</span></div>
-                  <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf" />
-                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="chorusRateSlider">Chorus Rate</label><span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span></div>
-                  <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus rate" />
-                  <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="chorusDepthSlider">Chorus Depth</label><span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span></div>
-                  <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="satDriveSlider">Tape Drive</label><span class="value-badge value-badge--red" id="satDriveValue">0%</span></div>
-                  <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Tape drive" />
-                  <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Driven</span></div>
-                </div>
+          </div>
+
+          <!-- Effects drawer — right side, opens with "Effects" button -->
+          <div id="effectsDrawer" class="controls-drawer controls-drawer--hidden">
+            <div class="controls-drawer-header">
+              <span class="controls-drawer-title">Effects Chain</span>
+              <button id="effectsCloseBtn" class="controls-drawer-btn" title="Close panel" aria-label="Close panel">&times;</button>
+            </div>
+            <div class="controls">
+              <div class="control-group">
+                <div class="control-header"><label for="eqLowSlider">EQ Low</label><span class="value-badge value-badge--green" id="eqLowValue">0 dB</span></div>
+                <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf" />
+                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
               </div>
-            </details>
+              <div class="control-group">
+                <div class="control-header"><label for="eqMidSlider">EQ Mid</label><span class="value-badge value-badge--green" id="eqMidValue">0 dB</span></div>
+                <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak" />
+                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="eqHighSlider">EQ High</label><span class="value-badge value-badge--green" id="eqHighValue">0 dB</span></div>
+                <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf" />
+                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="chorusRateSlider">Chorus Rate</label><span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span></div>
+                <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus rate" />
+                <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="chorusDepthSlider">Chorus Depth</label><span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span></div>
+                <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="satDriveSlider">Saturator</label><span class="value-badge value-badge--red" id="satDriveValue">0%</span></div>
+                <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Saturator" />
+                <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Saturated</span></div>
+              </div>
+              <div class="control-group control-group--8d">
+                <label class="toggle-row">
+                  <span class="toggle-label">
+                    <svg class="icon-headphones" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <path d="M3 18v-6a9 9 0 0 1 18 0v6"/>
+                      <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>
+                    </svg>
+                    8D Audio
+                  </span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="eightDToggle" class="toggle-input" aria-label="8D audio — headphones required" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <p class="control-hint" id="eightDHint">Use headphones for the binaural effect</p>
+                <div class="control-header" id="eightDSpeedRow" style="display:none">
+                  <label for="eightDSpeedSlider">Rotation Speed</label>
+                  <span class="value-badge value-badge--purple" id="eightDSpeedValue">0.5 Hz</span>
+                </div>
+                <input type="range" id="eightDSpeedSlider" class="slider slider--purple" min="1" max="20" value="5" step="1" aria-label="8D rotation speed" style="display:none" />
+                <div class="slider-ticks" id="eightDSpeedTicks" style="display:none"><span>Slow</span><span>0.5 Hz</span><span>Fast</span></div>
+              </div>
+              <div class="control-group control-group--hz">
+                <div class="control-header">
+                  <label>Hz Resonance</label>
+                  <span class="value-badge value-badge--indigo" id="hzValue">Off</span>
+                </div>
+                <div class="btn-hz-group" role="group" aria-label="Hz frequency resonance">
+                  <button class="btn-hz btn-hz--active" data-hz="off"  title="No frequency boost"                                 aria-pressed="true">Off</button>
+                  <button class="btn-hz" data-hz="432" title="432 Hz — Natural tuning, relaxation &amp; harmony"        aria-pressed="false">432</button>
+                  <button class="btn-hz" data-hz="528" title="528 Hz — Love frequency, transformation"                  aria-pressed="false">528</button>
+                  <button class="btn-hz" data-hz="639" title="639 Hz — Relationship healing, emotional balance"         aria-pressed="false">639</button>
+                  <button class="btn-hz" data-hz="741" title="741 Hz — Expression, intuition &amp; mental clarity"     aria-pressed="false">741</button>
+                  <button class="btn-hz" data-hz="852" title="852 Hz — Spiritual awareness &amp; inner strength"       aria-pressed="false">852</button>
+                  <button class="btn-hz" data-hz="963" title="963 Hz — Divine connection &amp; enlightenment"          aria-pressed="false">963</button>
+                </div>
+                <p class="control-hint" id="hzHint">Hover a frequency to learn more</p>
+              </div>
+            </div>
           </div>
 
           <!-- Visual Settings drawer — left side, opens with gear button -->
@@ -313,6 +353,7 @@
                   </svg>
                 </button>
                 <button id="controlsShowBtn" class="btn-controls-show" aria-label="Show controls">Controls</button>
+                <button id="effectsShowBtn" class="btn-controls-show" aria-label="Show effects">Effects</button>
               </div>
             </div>
           </div>

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -38,6 +38,16 @@ export class AudioEngine {
   // Analyser tapped from effects chain output for the spectrum visualizer
   private _analyserNode: AnalyserNode | null = null
 
+  // 8D binaural panner — sits after analyser, before destination
+  private _panner8D: PannerNode | null = null
+  private _8DEnabled = false
+  private _8DSpeed   = 0.5   // Hz, rotation rate
+  private _8DRafId:  number | null = null
+
+  // Fires each animation frame when 8D is enabled, with the current angle in radians.
+  // App.ts uses this to keep the orb rotation in sync with the panner.
+  public on8DAngleUpdate: ((angle: number) => void) | null = null
+
   // Incremented each time a new source node is started. Lets the 'ended'
   // handler distinguish "this source finished naturally" from "this source was
   // stopped early because we seeked or restarted."
@@ -66,6 +76,7 @@ export class AudioEngine {
   private _eq = { low: 0, mid: 0, high: 0 }
   private _chorus = { rate: 0.8, depth: 0 }
   private _saturationDrive = 0
+  private _hzFrequency: number | null = null
 
   private timeUpdateTimer: ReturnType<typeof setInterval> | null = null
 
@@ -107,6 +118,7 @@ export class AudioEngine {
       eq: { ...this._eq },
       chorus: { ...this._chorus },
       saturationDrive: this._saturationDrive,
+      hzFrequency: this._hzFrequency,
     }
   }
 
@@ -155,7 +167,16 @@ export class AudioEngine {
     this._analyserNode.minDecibels = -90
     this._analyserNode.maxDecibels = -10
     chainOutput.connect(this._analyserNode)
-    this._analyserNode.connect(this.context.destination)
+
+    // 8D panner sits after the analyser so visualisation sees the pre-spatial signal.
+    // Default position (0, 0, -1) = directly ahead — transparent when 8D is off.
+    this._panner8D = this.context.createPanner()
+    this._panner8D.panningModel  = 'equalpower'  // overridden to HRTF when 8D enabled
+    this._panner8D.positionX.value =  0
+    this._panner8D.positionY.value =  0
+    this._panner8D.positionZ.value = -1
+    this._analyserNode.connect(this._panner8D)
+    this._panner8D.connect(this.context.destination)
   }
 
   // File loading
@@ -334,6 +355,69 @@ export class AudioEngine {
     this.setChorusRate(params.chorus.rate)
     this.setChorusDepth(params.chorus.depth)
     this.setSaturationDrive(params.saturationDrive)
+    this.setHzFrequency(params.hzFrequency)
+  }
+
+  setHzFrequency(hz: number | null): void {
+    this._hzFrequency = hz
+    this._effectsChain?.setHzFrequency(hz)
+  }
+
+  // 8D binaural panning
+
+  set8DEnabled(enabled: boolean): void {
+    if (!this._panner8D) return
+    this._8DEnabled = enabled
+
+    if (enabled) {
+      // Switch to HRTF for binaural rendering and start the animation loop
+      this._panner8D.panningModel = 'HRTF'
+      this._start8DLoop()
+    } else {
+      // Stop the animation loop and return panner to a neutral position
+      this._stop8DLoop()
+      this._panner8D.panningModel  = 'equalpower'
+      this._panner8D.positionX.value =  0
+      this._panner8D.positionY.value =  0
+      this._panner8D.positionZ.value = -1
+      this.on8DAngleUpdate?.(0)
+    }
+  }
+
+  set8DSpeed(hz: number): void {
+    this._8DSpeed = Math.max(0.1, Math.min(2, hz))
+  }
+
+  get8DEnabled(): boolean { return this._8DEnabled }
+  get8DSpeed():   number  { return this._8DSpeed }
+
+  private _start8DLoop(): void {
+    if (this._8DRafId !== null) return
+    const tick = () => {
+      if (!this._8DEnabled || !this._panner8D) return
+      this._8DRafId = requestAnimationFrame(tick)
+
+      // Derive angle from wall time so the rotation is always smooth and
+      // never jumps when playback is paused or resumed.
+      const wallSec = performance.now() / 1000
+      const angle   = (wallSec * 2 * Math.PI * this._8DSpeed) % (2 * Math.PI)
+
+      // Place the sound source on a horizontal circle of radius 5 m
+      const r = 5
+      this._panner8D.positionX.value = r * Math.sin(angle)
+      this._panner8D.positionY.value = 0
+      this._panner8D.positionZ.value = -r * Math.cos(angle)
+
+      this.on8DAngleUpdate?.(angle)
+    }
+    this._8DRafId = requestAnimationFrame(tick)
+  }
+
+  private _stop8DLoop(): void {
+    if (this._8DRafId !== null) {
+      cancelAnimationFrame(this._8DRafId)
+      this._8DRafId = null
+    }
   }
 
   // Loop region control

--- a/src/audio/EffectsChain.ts
+++ b/src/audio/EffectsChain.ts
@@ -24,6 +24,9 @@ export class EffectsChain {
   private satNode!: WaveShaperNode
   private satDrive = 0
 
+  // Hz frequency resonance (Solfeggio peaking filter)
+  private hzFilter!: BiquadFilterNode
+
   // rAF handle for debouncing saturation curve updates
   private satRafId: number | null = null
 
@@ -74,6 +77,13 @@ export class EffectsChain {
     this.satNode.oversample = '4x'
     this.satNode.curve = this.buildSatCurve(0)
 
+    // Hz resonance peaking filter (gain=0 = transparent when off)
+    this.hzFilter = ctx.createBiquadFilter()
+    this.hzFilter.type = 'peaking'
+    this.hzFilter.frequency.value = 432
+    this.hzFilter.Q.value = 10
+    this.hzFilter.gain.value = 0
+
     // Output node - just a pass-through gain so callers get a stable node ref
     this.outputNode = ctx.createGain()
     this.outputNode.gain.value = 1.0
@@ -92,9 +102,10 @@ export class EffectsChain {
     this.chorusDryGain.connect(this.chorusMerge)
     this.chorusWetGain.connect(this.chorusMerge)
 
-    // Wire saturation and output
+    // Wire saturation → hz filter → output
     this.chorusMerge.connect(this.satNode)
-    this.satNode.connect(this.outputNode)
+    this.satNode.connect(this.hzFilter)
+    this.hzFilter.connect(this.outputNode)
 
     // Start the LFO - it runs continuously to avoid pitch glitches on start/stop
     if (ctx instanceof AudioContext) {
@@ -114,9 +125,13 @@ export class EffectsChain {
     this.eqMid.gain.value = params.eq.mid
     this.eqHigh.gain.value = params.eq.high
     this.chorusLfo.frequency.value = params.chorus.rate
-    this.chorusLfoGain.gain.value = params.chorus.depth * 0.01
-    this.chorusWetGain.gain.value = params.chorus.depth > 0 ? 0.5 : 0
+    this.chorusLfoGain.gain.value = params.chorus.depth * 0.015
+    this.chorusWetGain.gain.value = params.chorus.depth * 0.6
     this.satNode.curve = this.buildSatCurve(params.saturationDrive)
+    if (params.hzFrequency !== null) {
+      this.hzFilter.frequency.value = params.hzFrequency
+      this.hzFilter.gain.value = 4
+    }
 
     // Start LFO for offline context too
     this.chorusLfo.start()
@@ -142,9 +157,12 @@ export class EffectsChain {
   setChorusDepth(depth: number): void {
     const clamped = Math.max(0, Math.min(1, depth))
     const t = (this.ctx as AudioContext).currentTime
-    this.chorusLfoGain.gain.setTargetAtTime(clamped * 0.01, t, 0.01)
-    // Bring wet gain in when depth > 0, silence it when depth = 0
-    this.chorusWetGain.gain.setTargetAtTime(clamped > 0 ? 0.5 : 0, t, 0.01)
+    // Modulation range: 0 to 15 ms — proportional to depth so the rate slider
+    // has an audible effect even at low depth values.
+    this.chorusLfoGain.gain.setTargetAtTime(clamped * 0.015, t, 0.01)
+    // Wet gain scales proportionally with depth (0 to 60%).
+    // The old binary 0/0.5 jump meant 1% depth sounded the same as 100%.
+    this.chorusWetGain.gain.setTargetAtTime(clamped * 0.6, t, 0.01)
   }
 
   setSaturationDrive(drive: number): void {
@@ -157,24 +175,38 @@ export class EffectsChain {
     })
   }
 
+  setHzFrequency(hz: number | null): void {
+    const t = (this.ctx as AudioContext).currentTime
+    if (hz === null) {
+      this.hzFilter.gain.setTargetAtTime(0, t, 0.01)
+    } else {
+      this.hzFilter.frequency.value = hz
+      this.hzFilter.gain.setTargetAtTime(4, t, 0.01)
+    }
+  }
+
   getOutputNode(): AudioNode {
     return this.outputNode
   }
 
-  // Soft-clip waveshaping curve. drive=0 is a linear passthrough.
+  // Soft-clip waveshaping curve using a normalized tanh transfer function.
+  // drive=0: transparent (effectively linear)
+  // drive=1: clear but musical saturation — no harsh clipping
+  //
+  // Normalization: y = tanh(k*x) / tanh(k) guarantees that x=±1 always
+  // maps to y=±1, so there is zero gain change — only waveform shaping.
+  // The old formula violated this, amplifying quiet signals and crushing
+  // loud ones regardless of the drive setting.
   private buildSatCurve(drive: number): Float32Array<ArrayBuffer> {
     const n = 256
     const curve: Float32Array<ArrayBuffer> = new Float32Array(n)
-    const k = drive * 100
+    // k from ~0 (linear) to 6 (noticeable but never harsh saturation)
+    const k    = drive * 6 + 0.001
+    const norm = Math.tanh(k)
 
     for (let i = 0; i < n; i++) {
       const x = (i * 2) / n - 1  // -1 to +1
-      if (k === 0) {
-        curve[i] = x
-      } else {
-        // Standard soft-clip formula
-        curve[i] = ((3 + k) * x * 20 * (Math.PI / 180)) / (Math.PI + k * Math.abs(x))
-      }
+      curve[i] = Math.tanh(k * x) / norm
     }
 
     return curve

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -13,6 +13,7 @@ export const PRESETS: PresetDefinition[] = [
       eq: { low: 3, mid: -2, high: -4 },
       chorus: { rate: 0.8, depth: 0.15 },
       saturationDrive: 0.45,
+      hzFrequency: null,
     },
   },
   {
@@ -27,6 +28,7 @@ export const PRESETS: PresetDefinition[] = [
       eq: { low: 2, mid: 0, high: 1 },
       chorus: { rate: 0.3, depth: 0.30 },
       saturationDrive: 0.10,
+      hzFrequency: null,
     },
   },
   {
@@ -41,6 +43,7 @@ export const PRESETS: PresetDefinition[] = [
       eq: { low: 0, mid: -3, high: -2 },
       chorus: { rate: 0.15, depth: 0.40 },
       saturationDrive: 0.0,
+      hzFrequency: null,
     },
   },
   {
@@ -55,6 +58,7 @@ export const PRESETS: PresetDefinition[] = [
       eq: { low: 2, mid: 1, high: 6 },
       chorus: { rate: 4.0, depth: 0.70 },
       saturationDrive: 0.55,
+      hzFrequency: null,
     },
   },
 ]

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -767,6 +767,10 @@ body.is-playing .btn-play::before {
   --orange-dim: rgba(251, 146, 60, 0.15);
   --red: #f87171;
   --red-dim: rgba(248, 113, 113, 0.15);
+  --purple: #a78bfa;
+  --purple-dim: rgba(167, 139, 250, 0.15);
+  --indigo: #818cf8;
+  --indigo-dim: rgba(129, 140, 248, 0.15);
 }
 
 /* ── Preset cards ───────────────────────────────────────────────────────── */
@@ -1087,6 +1091,101 @@ body.is-playing .btn-play::before {
 .value-badge--red {
   color: var(--red);
   background: var(--red-dim);
+}
+
+.value-badge--purple {
+  color: var(--purple);
+  background: var(--purple-dim);
+}
+
+/* ── 8D Audio controls ──────────────────────────────────────────────────── */
+.slider--purple::-webkit-slider-thumb {
+  background: var(--purple);
+  box-shadow: 0 0 0 3px var(--purple-dim), 0 2px 6px rgba(0,0,0,0.4);
+}
+.slider--purple::-webkit-slider-thumb:hover {
+  box-shadow: 0 0 0 5px var(--purple-dim), 0 2px 8px rgba(0,0,0,0.5);
+}
+.slider--purple::-moz-range-thumb {
+  background: var(--purple);
+  box-shadow: 0 0 0 3px var(--purple-dim);
+}
+.slider--purple::-webkit-slider-runnable-track {
+  background: var(--purple-dim);
+}
+.slider--purple::-moz-range-track {
+  background: var(--purple-dim);
+}
+
+.control-group--8d {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+/* ── Hz Resonance controls ──────────────────────────────────────────────── */
+.value-badge--indigo {
+  color: var(--indigo);
+  background: var(--indigo-dim);
+}
+
+.control-group--hz {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.btn-hz-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.btn-hz {
+  flex: 1 1 auto;
+  min-width: 36px;
+  padding: 5px 6px;
+  border: 1px solid var(--border-2);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+
+.btn-hz:hover {
+  border-color: var(--indigo);
+  color: var(--indigo);
+  background: var(--indigo-dim);
+}
+
+.btn-hz:focus-visible {
+  box-shadow: 0 0 0 2px var(--indigo);
+}
+
+.btn-hz--active {
+  border-color: var(--indigo);
+  color: var(--indigo);
+  background: var(--indigo-dim);
+  box-shadow: 0 0 8px rgba(129, 140, 248, 0.25);
+}
+
+.control-hint {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.icon-headphones {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 /* ── Color Themes ───────────────────────────────────────────────────────── */

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface AudioParams {
   eq: EQParams
   chorus: ChorusParams
   saturationDrive: number   // 0 to 1
+  hzFrequency: number | null  // Solfeggio resonance Hz, null = off
 }
 
 export interface PresetDefinition {

--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -371,6 +371,8 @@ export class AnomalySphere {
   private bassPulse     = true
   private rotationSpeed = 1.0
   private orbBaseScale  = 1.0
+  private _8DEnabled    = false
+  private _8DAngle      = 0    // current panner angle in radians, set by AudioEngine callback
   private particleCount = 500
   private prevBass      = 0   // previous frame bass — used for transient detection
   private _loopPulseAmount = 0  // decays each frame; set to 1 on each loop cycle
@@ -735,10 +737,20 @@ export class AnomalySphere {
     const loopPulseFactor  = this._loopPulseAmount * 0.08
     this.mesh.scale.setScalar(this.orbBaseScale * (1.0 + pulseFactor + loopPulseFactor))
 
-    // Rotation slows with playback speed; user-adjustable rotation speed
-    const rotScale = (0.35 + this.speed * 0.65) * this.rotationSpeed
-    this.mesh.rotation.y += (0.0018 + bVis * 0.006) * rotScale
-    this.mesh.rotation.x += 0.0006 * rotScale
+    // Rotation: when 8D mode is active, the orb tracks the panner angle directly.
+    // Otherwise the normal audio-reactive rotation drives it.
+    if (this._8DEnabled) {
+      // Snap the Y rotation to the panner angle so the orb visually circles
+      // the listener in sync with the binaural sound position.
+      this.mesh.rotation.y = this._8DAngle
+      // Keep a gentle tilt animation on X so the orb stays alive
+      const rotScale = (0.35 + this.speed * 0.65) * this.rotationSpeed
+      this.mesh.rotation.x += 0.0006 * rotScale
+    } else {
+      const rotScale = (0.35 + this.speed * 0.65) * this.rotationSpeed
+      this.mesh.rotation.y += (0.0018 + bVis * 0.006) * rotScale
+      this.mesh.rotation.x += 0.0006 * rotScale
+    }
 
     // Particle color tracks the palette hue
     this.particleUniforms.uBass.value   = bVis
@@ -803,6 +815,9 @@ export class AnomalySphere {
     this.particleCount = Math.max(0, Math.min(3000, n))
     this.rebuildParticleGeo(this.particleCount)
   }
+
+  set8DMode(enabled: boolean): void  { this._8DEnabled = enabled }
+  set8DAngle(angle: number): void   { this._8DAngle = angle }
 
   setReactivity(v: number): void    { this.reactivity = Math.max(0, Math.min(1, v)) }
   setGlow(v: number): void          { this.glowMult = Math.max(0, Math.min(1.5, v)) }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -67,6 +67,11 @@ export class App {
   private controlsCloseBtn = document.getElementById('controlsCloseBtn')!
   private controlsShowBtn = document.getElementById('controlsShowBtn')!
 
+  // Effects drawer refs
+  private effectsDrawer   = document.getElementById('effectsDrawer')!
+  private effectsCloseBtn = document.getElementById('effectsCloseBtn')!
+  private effectsShowBtn  = document.getElementById('effectsShowBtn')!
+
   // Settings drawer refs
   private settingsDrawer   = document.getElementById('settingsDrawer')!
   private settingsCloseBtn = document.getElementById('settingsCloseBtn')!
@@ -100,6 +105,7 @@ export class App {
     this.wireKeyboard()
     this.wireCrossController()
     this.wireControlsPanel()
+    this.wireEffectsPanel()
     this.wireSettingsPanel()
     this.initMidi()
   }
@@ -118,6 +124,24 @@ export class App {
     this.controlsShowBtn.addEventListener('click', () => {
       this.controlsDrawer.classList.remove('controls-drawer--hidden')
       this.controlsShowBtn.style.display = 'none'
+      // Close effects drawer if open
+      this.effectsDrawer.classList.add('controls-drawer--hidden')
+      this.effectsShowBtn.style.display = ''
+    })
+  }
+
+  private wireEffectsPanel(): void {
+    this.effectsCloseBtn.addEventListener('click', () => {
+      this.effectsDrawer.classList.add('controls-drawer--hidden')
+      this.effectsShowBtn.style.display = ''
+    })
+    this.effectsShowBtn.addEventListener('click', () => {
+      this.effectsDrawer.classList.remove('controls-drawer--hidden')
+      this.effectsShowBtn.style.display = 'none'
+      // Close controls drawer if open
+      this.controlsDrawer.classList.add('controls-drawer--hidden')
+      this.controlsDrawer.classList.remove('controls-drawer--floating')
+      this.controlsShowBtn.style.display = ''
     })
   }
 
@@ -154,6 +178,14 @@ export class App {
     }
     this.effects.onChanged = () => {
       this.presets.clearActive()
+    }
+    this.effects.on8DChange = (enabled, _speed) => {
+      this.sphere?.set8DMode(enabled)
+      if (!enabled) this.sphere?.set8DAngle(0)
+    }
+    // Keep the orb rotation in sync with the 8D panner angle every animation frame
+    this.engine.on8DAngleUpdate = (angle) => {
+      this.sphere?.set8DAngle(angle)
     }
   }
 

--- a/src/ui/EffectsController.ts
+++ b/src/ui/EffectsController.ts
@@ -21,6 +21,30 @@ export class EffectsController {
   private satDriveSlider = document.getElementById('satDriveSlider') as HTMLInputElement
   private satDriveValue = document.getElementById('satDriveValue')!
 
+  private eightDToggle     = document.getElementById('eightDToggle')     as HTMLInputElement
+  private eightDSpeedSlider = document.getElementById('eightDSpeedSlider') as HTMLInputElement
+  private eightDSpeedValue  = document.getElementById('eightDSpeedValue')!
+  private eightDSpeedRow    = document.getElementById('eightDSpeedRow')!
+  private eightDSpeedTicks  = document.getElementById('eightDSpeedTicks')!
+  private eightDHint        = document.getElementById('eightDHint')!
+
+  private hzButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.btn-hz'))
+  private hzValue   = document.getElementById('hzValue')!
+  private hzHint    = document.getElementById('hzHint')!
+
+  private readonly HZ_LABELS: Record<string, string> = {
+    off:  'No frequency boost applied',
+    '432': '432 Hz — Natural tuning, relaxation & harmony',
+    '528': '528 Hz — Love frequency, transformation',
+    '639': '639 Hz — Relationship healing, emotional balance',
+    '741': '741 Hz — Expression, intuition & mental clarity',
+    '852': '852 Hz — Spiritual awareness & inner strength',
+    '963': '963 Hz — Divine connection & enlightenment',
+  }
+
+  // Fires when the 8D toggle changes so App.ts can sync the sphere
+  public on8DChange: ((enabled: boolean, speed: number) => void) | null = null
+
   // Fired after any slider change so App.ts can clear the active preset
   public onChanged: (() => void) | null = null
 
@@ -71,6 +95,56 @@ export class EffectsController {
       this.satDriveValue.textContent = `${this.satDriveSlider.value}%`
       this.onChanged?.()
     })
+
+    this.eightDToggle.addEventListener('change', () => {
+      const enabled = this.eightDToggle.checked
+      const speed   = this._get8DSpeed()
+      this.engine.set8DEnabled(enabled)
+      this._show8DSpeedControls(enabled)
+      this.on8DChange?.(enabled, speed)
+      this.onChanged?.()
+    })
+
+    this.eightDSpeedSlider.addEventListener('input', () => {
+      const speed = this._get8DSpeed()
+      this.engine.set8DSpeed(speed)
+      this.eightDSpeedValue.textContent = `${speed.toFixed(1)} Hz`
+      this.on8DChange?.(this.eightDToggle.checked, speed)
+    })
+
+    this.hzButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const raw = btn.dataset.hz
+        const hz = raw === 'off' ? null : parseInt(raw!, 10)
+        this.engine.setHzFrequency(hz)
+        this._updateHzButtons(hz)
+        this.onChanged?.()
+      })
+    })
+  }
+
+  private _updateHzButtons(hz: number | null): void {
+    const target = hz === null ? 'off' : String(hz)
+    this.hzButtons.forEach(btn => {
+      const active = btn.dataset.hz === target
+      btn.classList.toggle('btn-hz--active', active)
+      btn.setAttribute('aria-pressed', String(active))
+    })
+    this.hzValue.textContent = hz === null ? 'Off' : `${hz} Hz`
+    this.hzHint.textContent = this.HZ_LABELS[target] ?? ''
+  }
+
+  private _get8DSpeed(): number {
+    // Slider range 1-20 maps to 0.1-2.0 Hz (divide by 10)
+    return parseFloat(this.eightDSpeedSlider.value) / 10
+  }
+
+  private _show8DSpeedControls(show: boolean): void {
+    const display = show ? '' : 'none'
+    this.eightDSpeedRow.style.display  = display
+    this.eightDSpeedSlider.style.display = display
+    this.eightDSpeedTicks.style.display  = display
+    this.eightDHint.style.display = show ? 'none' : ''
   }
 
   // Syncs slider positions and badges to a given params object.
@@ -93,5 +167,7 @@ export class EffectsController {
     const satPct = Math.round(params.saturationDrive * 100)
     this.satDriveSlider.value = String(satPct)
     this.satDriveValue.textContent = `${satPct}%`
+
+    this._updateHzButtons(params.hzFrequency)
   }
 }


### PR DESCRIPTION
- Split controls drawer (speed, reverb, volume) from a new effects drawer (EQ, chorus, saturation, 8D audio) — each opened by its own button in the transport bar; opening one closes the other
- Add Hz Resonance effect: BiquadFilter peaking node at end of effects chain; 7-button group (Off, 432, 528, 639, 741, 852, 963 Hz) with Solfeggio frequency descriptions shown on selection
- Wire hzFrequency through AudioParams, presets, offline export, and preset sync

Closes #21