### PR TITLE
feat: full mobile + PWA support (issues #9 and #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Slo-Fi" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="description" content="Professional-grade audio slow-down tool with convolution reverb. Runs entirely in your browser — no uploads, no tracking." />
     <meta name="theme-color" content="#080810" />
     <title>Slo-Fi — Your Browser Is the Studio</title>
@@ -381,6 +385,14 @@
               </div>
               <div class="transport-right">
                 <span class="time-total" id="duration">0:00</span>
+                <button id="fullscreenBtn" class="btn btn-icon btn-fullscreen" aria-label="Enter fullscreen" title="Fullscreen (F)">
+                  <svg id="iconFullscreenEnter" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M2 6V2h4M10 2h4v4M14 10v4h-4M6 14H2v-4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  <svg id="iconFullscreenExit" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" style="display:none">
+                    <path d="M6 2v4H2M14 6h-4V2M10 14v-4h4M2 10h4v4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
                 <button id="settingsShowBtn" class="btn-settings-show" aria-label="Visual settings" title="Visual settings">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,7 @@
   "description": "Professional-grade browser audio slow-down tool with convolution reverb",
   "start_url": "/",
   "display": "standalone",
+  "orientation": "any",
   "background_color": "#080810",
   "theme_color": "#080810",
   "icons": [
@@ -11,7 +12,13 @@
       "src": "/favicon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'slo-fi-v1'
+const CACHE = 'slo-fi-v2'
 const SHELL = ['/', '/index.html', '/manifest.json', '/favicon.svg']
 
 self.addEventListener('install', (e) => {
@@ -17,7 +17,20 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return
+  // Serve from cache first. On a miss, fetch from the network and cache the
+  // response so Vite-hashed JS/CSS bundles are available on the next offline load.
+  // Audio files are loaded via File.arrayBuffer() and never pass through here,
+  // so no audio data ever enters the cache.
   e.respondWith(
-    caches.match(e.request).then((cached) => cached ?? fetch(e.request))
+    caches.match(e.request).then((cached) => {
+      if (cached) return cached
+      return fetch(e.request).then((res) => {
+        if (res.ok && e.request.url.startsWith(self.location.origin)) {
+          const clone = res.clone()
+          caches.open(CACHE).then((c) => c.put(e.request, clone))
+        }
+        return res
+      })
+    })
   )
 })

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -38,6 +38,12 @@ export class AudioEngine {
   // Analyser tapped from effects chain output for the spectrum visualizer
   private _analyserNode: AnalyserNode | null = null
 
+  // Hidden <audio> element whose srcObject is a silent MediaStream from this
+  // context. Playing it keeps the iOS audio session alive in the background
+  // without exposing a file duration - so Control Center shows our
+  // setPositionState values instead of a looping 0-1 second counter.
+  private _keepaliveEl: HTMLAudioElement | null = null
+
   // 8D binaural panner — sits after analyser, before destination
   private _panner8D: PannerNode | null = null
   private _8DEnabled = false
@@ -178,7 +184,25 @@ export class AudioEngine {
     this._panner8D.positionZ.value = -1
     this._analyserNode.connect(this._panner8D)
     this._panner8D.connect(this.context.destination)
+
+    // Create a silent MediaStream tap from the audio graph and wire it to a
+    // hidden <audio> element. Playing a MediaStream source keeps the iOS audio
+    // session alive in the background. Because a MediaStream has no file
+    // duration, iOS cannot display a looping 0-1 s counter in Control Center,
+    // so our navigator.mediaSession.setPositionState calls take full effect.
+    const keepaliveDest = this.context.createMediaStreamDestination()
+    const keepaliveGain = this.context.createGain()
+    keepaliveGain.gain.value = 0
+    keepaliveGain.connect(keepaliveDest)
+
+    const el = document.createElement('audio')
+    el.srcObject = keepaliveDest.stream
+    el.setAttribute('playsinline', '')
+    el.setAttribute('aria-hidden', 'true')
+    this._keepaliveEl = el
   }
+
+  get keepaliveEl(): HTMLAudioElement | null { return this._keepaliveEl }
 
   // File loading
 
@@ -514,5 +538,27 @@ export class AudioEngine {
       clearInterval(this.timeUpdateTimer)
       this.timeUpdateTimer = null
     }
+  }
+
+  // Ramps master gain to silence before the OS suspends the AudioContext.
+  // A 30ms linear fade eliminates the click that iOS produces when it cuts
+  // the audio session abruptly as the app goes to the background.
+  prepareForBackground(): void {
+    if (!this.context || !this.masterGainNode || !this._isPlaying) return
+    const t = this.context.currentTime
+    this.masterGainNode.gain.cancelScheduledValues(t)
+    this.masterGainNode.gain.setValueAtTime(this._volume, t)
+    this.masterGainNode.gain.linearRampToValueAtTime(0, t + 0.03)
+  }
+
+  // Resumes the AudioContext after a background suspension and fades gain
+  // back up so the return from background sounds clean rather than popping in.
+  resumeFromBackground(): void {
+    if (!this.context || !this.masterGainNode) return
+    this.context.resume().catch(() => {})
+    const t = this.context.currentTime
+    this.masterGainNode.gain.cancelScheduledValues(t)
+    this.masterGainNode.gain.setValueAtTime(0, t)
+    this.masterGainNode.gain.linearRampToValueAtTime(this._volume, t + 0.05)
   }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -949,8 +949,31 @@ body.is-playing .btn-play::before {
     left: 0;
     width: auto;
     border-radius: var(--radius) var(--radius) 0 0;
-    bottom: 148px;
+    bottom: 175px;
     max-height: calc(100vh - 280px);
+  }
+
+  /* Two-row transport layout so Controls and Effects buttons are never hidden.
+     Row 1: current time + transport buttons.
+     Row 2: total time + fullscreen + settings + Controls + Effects. */
+  .transport-row {
+    flex-wrap: wrap;
+    padding: 6px 12px 2px;
+    gap: 4px 6px;
+  }
+
+  .transport {
+    flex: 1;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .transport-right {
+    flex-basis: 100%;
+    margin-left: 0;
+    justify-content: center;
+    gap: 8px;
+    padding-bottom: 4px;
   }
 
   /* Landing page: scale down rings and text on mobile */
@@ -2026,5 +2049,93 @@ body.is-paused .site-footer {
 /* Mobile: keep waveform at a usable height */
 @media (max-width: 480px) {
   .waveform { height: 60px; }
+}
+
+/* ── Waveform touch behavior ────────────────────────────────────────────── */
+/* Suppress the iOS long-press callout and text-selection highlight that
+   would otherwise appear when the user swipes to scrub. touch-action:none
+   hands all pointer events to the JS handler and removes the 300ms tap
+   delay on Android browsers. */
+.waveform {
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+}
+
+/* ── Safe area insets (iPhone X+ notch / Dynamic Island) ────────────────── */
+/* Extends the bottom transport bar to fill the space above the home
+   indicator on notched iPhones. env() resolves to 0 on non-notched devices. */
+.player-bottom {
+  padding-bottom: max(0px, env(safe-area-inset-bottom));
+}
+
+/* Inside fullscreen the insets collapse to zero so no extra padding needed */
+@media (display-mode: fullscreen) {
+  .player-bottom { padding-bottom: 0; }
+}
+
+/* ── Safe-area-aware drawer positioning on notched phones ───────────────── */
+/* The drawers sit 148px above the transport bar. On notched phones that bar
+   itself gets extra bottom padding, so the drawers need to shift up too. */
+@media (max-width: 600px) {
+  .controls-drawer,
+  .settings-drawer {
+    bottom: calc(175px + env(safe-area-inset-bottom));
+  }
+}
+
+/* ── iOS momentum scroll for drawers ────────────────────────────────────── */
+/* Gives the panel scroll areas a native rubber-band feel on iOS Safari. */
+.controls-drawer,
+.settings-drawer {
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Fullscreen button ──────────────────────────────────────────────────── */
+.btn-fullscreen {
+  opacity: 0.75;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.btn-fullscreen:hover {
+  opacity: 1;
+}
+
+/* When in fullscreen the exit-icon button gets a subtle accent tint so
+   the user knows the mode is active */
+:fullscreen .btn-fullscreen,
+:-webkit-full-screen .btn-fullscreen {
+  opacity: 1;
+  color: var(--accent-bright);
+}
+
+/* Hide the fullscreen button on touch devices that do not support the
+   Fullscreen API (i.e. iOS Safari). @supports checks for :fullscreen selector
+   support; browsers without requestFullscreen also lack this pseudo-class. */
+@supports not (selector(:fullscreen)) {
+  @media (pointer: coarse) {
+    .btn-fullscreen { display: none; }
+  }
+}
+
+/* ── Fullscreen layout fill ─────────────────────────────────────────────── */
+:fullscreen #app,
+:-webkit-full-screen #app {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── Tablet / large phone (601-768px) ───────────────────────────────────── */
+/* Slightly taller waveform and narrower capped drawers for wider phones and
+   small tablets where the 600px phone rules would be too cramped. */
+@media (min-width: 601px) and (max-width: 768px) {
+  .waveform { height: 80px; }
+
+  .controls-drawer,
+  .settings-drawer {
+    max-width: 380px;
+  }
 }
 

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -6,6 +6,7 @@ import { StarOverlay } from './StarOverlay'
 import { PresetController } from './PresetController'
 import { EffectsController } from './EffectsController'
 import { ExportController } from './ExportController'
+import { MobileController } from './MobileController'
 import type { AudioParams } from '../types'
 
 function formatTime(seconds: number): string {
@@ -29,6 +30,7 @@ export class App {
   private presets: PresetController
   private effects: EffectsController
   private exporter: ExportController
+  private _mobile!: MobileController
   // Core DOM refs
   private dropzone = document.getElementById('dropzone')!
   private fileInput = document.getElementById('fileInput') as HTMLInputElement
@@ -102,6 +104,21 @@ export class App {
     this.wireControlsPanel()
     this.wireEffectsPanel()
     this.wireSettingsPanel()
+
+    // Wire up mobile APIs: Media Session, Fullscreen, Vibration, and
+    // AudioContext background recovery via visibilitychange.
+    this._mobile = new MobileController(this.engine)
+    this._mobile.onExternalPlay  = () => { this.setPlayingState(true);  this.sphere?.start() }
+    this._mobile.onExternalPause = () => { this.setPlayingState(false); this.sphere?.stop()  }
+    this._mobile.onExternalStop  = () => {
+      this.setPlayingState(false)
+      this.waveform.setProgress(0)
+      this.currentTimeEl.textContent = '0:00'
+      this.sphere?.stop()
+      this._mobile.stopSilenceLoop()
+    }
+    const fsBtn = document.getElementById('fullscreenBtn') as HTMLButtonElement | null
+    if (fsBtn) this._mobile.bindFullscreenBtn(fsBtn)
   }
 
   private wireControlsPanel(): void {
@@ -188,11 +205,14 @@ export class App {
       this.setPlayingState(false)
       this.waveform.setProgress(0)
       this.sphere?.stop()
+      this._mobile?.stopSilenceLoop()
     }
     this.engine.onTimeUpdate = (current, duration) => {
       this.currentTimeEl.textContent = formatTime(current)
       if (duration > 0) {
         this.waveform.setProgress(current / duration)
+        // Keep the lock screen position scrubber moving in real time
+        this._mobile?.updatePlaybackState(this.engine.isPlaying)
       }
     }
     this.engine.onLoopCycle = () => {
@@ -232,6 +252,7 @@ export class App {
       this.waveform.setProgress(0)
       this.currentTimeEl.textContent = '0:00'
       this.sphere?.stop()
+      this._mobile?.stopSilenceLoop()
     })
     this.rewindBtn.addEventListener('click', () => {
       this.engine.seek(Math.max(0, this.engine.currentTime - 5))
@@ -240,6 +261,7 @@ export class App {
     // Waveform seek
     this.waveform.onSeek = (ratio) => {
       this.engine.seek(ratio * this.engine.duration)
+      this._mobile?.hapticSeek()
     }
 
     // Waveform loop handle drag
@@ -382,6 +404,10 @@ export class App {
         case 'L':
           this.loopBtn.click()
           break
+        case 'f':
+        case 'F':
+          ;(document.getElementById('fullscreenBtn') as HTMLButtonElement | null)?.click()
+          break
       }
     })
   }
@@ -421,6 +447,8 @@ export class App {
       const baseName = file.name.replace(/\.[^.]+$/, '')
       this.trackName.textContent = baseName
       this.exporter.trackName = baseName
+      // Push the track title to the OS lock screen / notification card
+      this._mobile.setMediaSessionMetadata(baseName)
 
       this._baseBpm = detectBpm(this.engine.getBuffer()!)
       this.updateBpmDisplay()
@@ -491,10 +519,17 @@ export class App {
       this.engine.pause()
       this.setPlayingState(false)
       this.sphere?.stop()
+      this._mobile.hapticPause()
+      this._mobile.updatePlaybackState(false)
+      // Keep the silence loop running during pause so the iOS audio session
+      // and lock screen controls stay visible while the track is paused.
     } else {
       this.engine.play()
       this.setPlayingState(true)
       this.sphere?.start()
+      this._mobile.hapticPlay()
+      this._mobile.updatePlaybackState(true)
+      this._mobile.ensureSilenceLoop()
     }
   }
 
@@ -502,6 +537,8 @@ export class App {
     this.playPauseBtn.setAttribute('aria-label', playing ? 'Pause' : 'Play')
     document.body.classList.toggle('is-playing', playing)
     document.body.classList.toggle('is-paused', !playing)
+    // Keep the OS lock screen transport badge in sync with the in-app state
+    this._mobile?.updatePlaybackState(playing)
   }
 
   private showPlayer(): void {

--- a/src/ui/MobileController.ts
+++ b/src/ui/MobileController.ts
@@ -1,0 +1,232 @@
+import type { AudioEngine } from '../audio/AudioEngine'
+
+// Haptic pulse durations in milliseconds. Short and distinct so they feel
+// like confirmation taps rather than interruptions.
+const HAPTIC_PLAY  = [12]
+const HAPTIC_PAUSE = [8]
+const HAPTIC_SEEK  = [4]
+
+// MobileController owns all mobile-specific browser APIs:
+//   - Media Session API: populates the OS lock screen / notification transport
+//   - Fullscreen API: enters and exits browser fullscreen
+//   - Vibration API: short haptic feedback on transport interactions
+//   - visibilitychange: resumes the AudioContext after a background suspension
+//
+// This follows the same controller pattern as PresetController and EffectsController.
+// App.ts wires the onExternal* callbacks to keep its own UI state in sync when
+// the user operates playback from the lock screen.
+
+export class MobileController {
+  private _engine: AudioEngine
+
+  // Callbacks assigned by App.ts so lock screen actions update the in-app UI
+  public onExternalPlay:  (() => void) | null = null
+  public onExternalPause: (() => void) | null = null
+  public onExternalStop:  (() => void) | null = null
+
+  // Reference to the engine's keepalive audio element (set after first play).
+  private _silentAudio: HTMLAudioElement | null = null
+
+  private _onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      // Fade master gain to zero before iOS suspends the AudioContext so
+      // there is no harsh click when the app goes to the background.
+      this._engine.prepareForBackground()
+      // Keep the lock screen card visible by marking the session as paused
+      // rather than letting the OS infer it has ended.
+      if ('mediaSession' in navigator) {
+        navigator.mediaSession.playbackState = 'paused'
+      }
+    } else if (document.visibilityState === 'visible') {
+      // Resume the AudioContext and fade gain back up cleanly.
+      this._engine.resumeFromBackground()
+      // Also restart the silence loop in case iOS paused the audio element
+      if (this._engine.isPlaying) this.ensureSilenceLoop()
+      if ('mediaSession' in navigator) {
+        navigator.mediaSession.playbackState =
+          this._engine.isPlaying ? 'playing' : 'paused'
+      }
+    }
+  }
+
+  constructor(engine: AudioEngine) {
+    this._engine = engine
+    document.addEventListener('visibilitychange', this._onVisibilityChange)
+    this._registerMediaSessionHandlers()
+  }
+
+  // Set the track title on the OS lock screen and notification area.
+  // Call this each time a new file is loaded.
+  setMediaSessionMetadata(title: string): void {
+    if (!('mediaSession' in navigator)) return
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title,
+      artist: 'Slo-Fi',
+      album:  '',
+    })
+  }
+
+  // Sync the lock screen playback state and position scrubber.
+  // Call this on every play, pause, seek, and time update.
+  updatePlaybackState(playing: boolean): void {
+    if (!('mediaSession' in navigator)) return
+    navigator.mediaSession.playbackState = playing ? 'playing' : 'paused'
+
+    const dur = this._engine.duration
+    if (dur > 0) {
+      try {
+        navigator.mediaSession.setPositionState({
+          duration:     dur,
+          playbackRate: this._engine.getParams().playbackRate,
+          position:     Math.min(this._engine.currentTime, dur),
+        })
+      } catch {
+        // setPositionState throws on some browsers when position > duration
+        // during a seek transition. Swallow so the UI never breaks.
+      }
+    }
+  }
+
+  // Wire the fullscreen toggle button. Handles both the standard and webkit
+  // prefixed APIs so it works on older mobile browsers.
+  bindFullscreenBtn(btn: HTMLButtonElement): void {
+    btn.addEventListener('click', () => this._toggleFullscreen())
+    document.addEventListener('fullscreenchange',        () => this._syncFullscreenIcon(btn))
+    document.addEventListener('webkitfullscreenchange',  () => this._syncFullscreenIcon(btn))
+  }
+
+  // Short haptic pulse confirming that playback has started.
+  hapticPlay(): void { this._vibrate(HAPTIC_PLAY) }
+
+  // Short haptic pulse confirming that playback has paused.
+  hapticPause(): void { this._vibrate(HAPTIC_PAUSE) }
+
+  // Very brief tick for waveform seek interactions.
+  hapticSeek(): void { this._vibrate(HAPTIC_SEEK) }
+
+  // Starts the engine's keepalive audio element (a silent MediaStream source)
+  // to hold the iOS audio session open. Because the source is a live MediaStream
+  // rather than a file, iOS has no duration to display in Control Center, so
+  // our setPositionState calls are the only position data it can show.
+  // Call this from any user-initiated play action.
+  ensureSilenceLoop(): void {
+    if (!this._silentAudio) {
+      this._silentAudio = this._engine.keepaliveEl
+    }
+    if (this._silentAudio && this._silentAudio.paused) {
+      this._silentAudio.play().catch(() => {})
+    }
+  }
+
+  // Pauses the keepalive element - call when playback is fully stopped (not on
+  // pause) so the iOS audio session can end cleanly.
+  stopSilenceLoop(): void {
+    if (this._silentAudio && !this._silentAudio.paused) {
+      this._silentAudio.pause()
+    }
+  }
+
+  // Remove the visibilitychange listener and unregister Media Session handlers.
+  // Call this if the app is ever torn down.
+  destroy(): void {
+    document.removeEventListener('visibilitychange', this._onVisibilityChange)
+    this.stopSilenceLoop()
+    if (!('mediaSession' in navigator)) return
+    const actions: MediaSessionAction[] = ['play', 'pause', 'stop', 'seekto', 'previoustrack', 'nexttrack']
+    for (const action of actions) {
+      try { navigator.mediaSession.setActionHandler(action, null) } catch {}
+    }
+  }
+
+  // Register OS transport controls. The handlers call engine methods directly
+  // then fire the onExternal* callbacks so App.ts can update button icons and
+  // the 3D orb state.
+  private _registerMediaSessionHandlers(): void {
+    if (!('mediaSession' in navigator)) return
+
+    const ms = navigator.mediaSession
+
+    ms.setActionHandler('play', () => {
+      this._engine.play()
+      this.ensureSilenceLoop()
+      this.onExternalPlay?.()
+    })
+
+    ms.setActionHandler('pause', () => {
+      this._engine.pause()
+      this.onExternalPause?.()
+    })
+
+    ms.setActionHandler('stop', () => {
+      this._engine.stop()
+      this.onExternalStop?.()
+    })
+
+    ms.setActionHandler('seekto', (details) => {
+      if (details.seekTime != null) {
+        this._engine.seek(details.seekTime)
+      }
+    })
+
+    ms.setActionHandler('seekbackward', (details) => {
+      const skip = details.seekOffset ?? 10
+      this._engine.seek(Math.max(0, this._engine.currentTime - skip))
+    })
+
+    ms.setActionHandler('seekforward', (details) => {
+      const skip = details.seekOffset ?? 10
+      this._engine.seek(Math.min(this._engine.duration, this._engine.currentTime + skip))
+    })
+
+    ms.setActionHandler('previoustrack', () => {
+      // No previous track concept in Slo-Fi, so seek back to the start instead.
+      this._engine.seek(0)
+    })
+
+    try {
+      // 'nexttrack' is not meaningful here. Unregister to hide the button.
+      ms.setActionHandler('nexttrack', null)
+    } catch {}
+  }
+
+  private _toggleFullscreen(): void {
+    const doc = document as Document & {
+      webkitFullscreenElement?: Element | null
+      webkitExitFullscreen?: () => Promise<void>
+    }
+    const el = document.documentElement as HTMLElement & {
+      webkitRequestFullscreen?: () => Promise<void>
+    }
+
+    const isFs = !!document.fullscreenElement || !!doc.webkitFullscreenElement
+
+    if (!isFs) {
+      const req = el.requestFullscreen?.() ?? el.webkitRequestFullscreen?.()
+      req?.catch(() => {
+        // Fullscreen request denied or unsupported (e.g. iOS Safari). Swallow
+        // silently so the button never throws a visible error.
+      })
+    } else {
+      const ex = document.exitFullscreen?.() ?? doc.webkitExitFullscreen?.()
+      ex?.catch(() => {})
+    }
+  }
+
+  private _syncFullscreenIcon(btn: HTMLButtonElement): void {
+    const doc = document as Document & { webkitFullscreenElement?: Element | null }
+    const isFs = !!document.fullscreenElement || !!doc.webkitFullscreenElement
+
+    btn.setAttribute('aria-label', isFs ? 'Exit fullscreen' : 'Enter fullscreen')
+    btn.setAttribute('title',      isFs ? 'Exit fullscreen (F)' : 'Enter fullscreen (F)')
+
+    const enter = btn.querySelector<HTMLElement>('#iconFullscreenEnter')
+    const exit  = btn.querySelector<HTMLElement>('#iconFullscreenExit')
+    if (enter) enter.style.display = isFs ? 'none' : ''
+    if (exit)  exit.style.display  = isFs ? ''     : 'none'
+  }
+
+  private _vibrate(pattern: number[]): void {
+    if (!('vibrate' in navigator)) return
+    try { navigator.vibrate(pattern) } catch {}
+  }
+}

--- a/src/ui/Waveform.ts
+++ b/src/ui/Waveform.ts
@@ -198,18 +198,42 @@ export class Waveform {
   private bindEvents(): void {
     let dragging = false
 
+    // Pending RAF for touch-seek throttling - ensures the audio engine seek
+    // fires at most once per animation frame so rapid touchmove events don't
+    // recreate the source node faster than it can settle.
+    let _touchSeekRaf: number | null = null
+    let _pendingTouchX = 0
+
     const seekAt = (clientX: number) => {
       const rect = this.canvas.getBoundingClientRect()
       const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
       this._onSeek?.(ratio)
     }
 
-    // Returns which loop handle is within 8px of the click x, or null
-    const hitHandle = (clientX: number): 'start' | 'end' | null => {
+    // Updates the waveform playhead position visually without triggering an
+    // audio seek - used to give instant visual feedback during touch scrubbing.
+    const updateVisualProgress = (clientX: number) => {
+      const rect = this.canvas.getBoundingClientRect()
+      this.progress = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+      this.draw()
+    }
+
+    const seekAtThrottled = (clientX: number) => {
+      _pendingTouchX = clientX
+      if (_touchSeekRaf !== null) return
+      _touchSeekRaf = requestAnimationFrame(() => {
+        _touchSeekRaf = null
+        seekAt(_pendingTouchX)
+      })
+    }
+
+    // Returns which loop handle is within `radius` px of the click x, or null.
+    // Mouse events use 8px for precision; touch events pass 20px for finger accuracy.
+    const hitHandle = (clientX: number, radius = 8): 'start' | 'end' | null => {
       const rect = this.canvas.getBoundingClientRect()
       const x = clientX - rect.left
-      if (Math.abs(x - this._loopStart * rect.width) <= 8) return 'start'
-      if (Math.abs(x - this._loopEnd   * rect.width) <= 8) return 'end'
+      if (Math.abs(x - this._loopStart * rect.width) <= radius) return 'start'
+      if (Math.abs(x - this._loopEnd   * rect.width) <= radius) return 'end'
       return null
     }
 
@@ -276,7 +300,8 @@ export class Waveform {
     // Touch support
     this.canvas.addEventListener('touchstart', (e) => {
       e.preventDefault()
-      const hit = hitHandle(e.touches[0].clientX)
+      // Use a 20px radius for touch so loop handles are easy to grab with a finger
+      const hit = hitHandle(e.touches[0].clientX, 20)
       if (hit) {
         this._dragTarget = hit
         return
@@ -299,11 +324,19 @@ export class Waveform {
         this.draw()
         return
       }
-      seekAt(touch.clientX)
+      // Update the playhead position visually on every touchmove for smooth
+      // feedback, then throttle the actual audio seek to once per RAF so the
+      // source node isn't recreated faster than it can settle.
+      updateVisualProgress(touch.clientX)
+      seekAtThrottled(touch.clientX)
     }, { passive: false })
 
     this.canvas.addEventListener('touchend', () => {
       this._dragTarget = null
+      if (_touchSeekRaf !== null) {
+        cancelAnimationFrame(_touchSeekRaf)
+        _touchSeekRaf = null
+      }
     })
 
     // Keyboard


### PR DESCRIPTION
## Summary

* **Mobile-first layout**: 
    * Two-row flex transport on small screens.
    * 44px touch targets.
    * Safe-area insets for notch/home-bar devices.
    * Dedicated tablet breakpoint.
* **Touch gestures**: 
    * Swipe-to-scrub waveform with instant visual feedback every frame.
    * `requestAnimationFrame` (RAF)-throttled audio seek.
    * 20px touch hit radius on loop handles.
* **PWA full-screen**: 
    * Fullscreen API (with `webkit` prefix fallback) toggled via toolbar button or `F` key.
    * Dynamic icon swaps on enter/exit.
* **Haptic feedback**: 
    * Vibration API on play (**12ms**), pause (**8ms**), and seek (**4ms**).
    * *Note: Android only; silent no-op on iOS/desktop.*
* **Lock screen / Control Center**: 
    * Media Session API integration with metadata and artwork.
    * Handlers for play, pause, stop, seek-backward, and seek-forward.
    * Live `setPositionState` updates.
* **iOS background audio**: 
    * Keepalive `<audio>` element backed by `MediaStreamDestinationNode` to hold the iOS `AVAudioSession` open.
    * `prepareForBackground()`: Fades gain to zero over **30ms** before suspension to prevent "harsh clicks."
    * `resumeFromBackground()`: Fades volume back in on app return.
* **Service worker**: Runtime caching of Vite-hashed JS/CSS bundles for full offline support.
* **manifest.json**: Configured `orientation: any` with split maskable/any icon entries.

---

## Closes

Closes #9
Closes #10

---

## Test plan

- [x] **iOS Safari (Standalone PWA)**: Load a file; verify lock screen shows title, artwork, and transport buttons.
- [x] **Control Center**: Scrub audio; verify position updates correctly without 0-1s looping issues.
- [x] **App Switching**: Switch apps while playing; audio should continue without a "click" on exit.
- [x] **App Return**: Return to app; audio should resume at the correct volume level.
- [x] **Waveform Interaction**: Swipe waveform on mobile; playhead should follow finger smoothly.
- [x] **Fullscreen**: Toggle via button and `F` key (desktop); verify icon state changes.
- [x] **Android PWA**: Install and verify haptics fire on play/pause.
- [x] **Offline Mode**: Perform a hard-reload while offline; app should load from service worker cache.