### PR TITLE
feat(security): HTTP headers, file size guard, decode progress UI

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,9 +54,29 @@ Slo-Fi's security posture is built into the architecture itself. Audio is proces
 | **No audio uploads** | Audio is decoded with `AudioContext.decodeAudioData()` from a local `File` object. No `fetch`, `XHR`, or WebSocket is used for audio data at any point. |
 | **No persistent audio storage** | `AudioBuffer` instances live only in memory. No writes to `localStorage`, `IndexedDB`, or the Cache API for audio content. The PWA service worker (`sw.js`) caches only static app shell assets — never audio data. Closing the tab frees all audio memory. |
 | **No third-party scripts** | Zero analytics, zero tracking pixels, zero CDN-loaded runtime libraries. All dependencies are bundled and reviewed at build time. |
-| **Content Security Policy** | Strict CSP headers restrict resource origins and block inline script injection. |
+| **Content Security Policy** | A strict CSP is enforced via `public/_headers` on Cloudflare Pages. It restricts resource origins, blocks inline script injection, and prevents framing (`frame-ancestors 'none'`). |
 
 This architecture makes Slo-Fi safe to use with sensitive, unreleased, or proprietary audio material.
+
+<br/>
+
+---
+
+<br/>
+
+## HTTP Security Headers
+
+All HTTP responses from the Cloudflare Pages deployment are governed by `public/_headers`. The full set of enforced headers and their rationale:
+
+| Header | Value | Rationale |
+|:---|:---|:---|
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'` | Restricts all resource origins to same-site. `style-src 'unsafe-inline'` is required for runtime CSS custom property writes via `element.style.setProperty()`. `connect-src 'self'` is required for the PWA service worker to cache static assets. `frame-ancestors 'none'` prevents clickjacking. |
+| `X-Frame-Options` | `DENY` | Legacy clickjacking protection for browsers that do not honour CSP `frame-ancestors`. |
+| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing attacks on served assets. |
+| `Referrer-Policy` | `no-referrer` | No `Referer` header is sent on any navigation away from the app. |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), display-capture=()` | Explicitly disables browser APIs Slo-Fi never uses. Closes the attack surface for those APIs should a script injection ever occur. Web Audio (`AudioContext`) is not gated by `Permissions-Policy` and is unaffected. |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Isolates the browsing context; prevents cross-origin windows from holding a reference to this page. |
+| `Cross-Origin-Resource-Policy` | `same-origin` | Prevents other origins from loading Slo-Fi's served resources. |
 
 <br/>
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), display-capture=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -1,6 +1,8 @@
 import { EffectsChain } from './EffectsChain'
 import type { AudioParams } from '../types'
 
+export const MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024
+
 // Builds an exponential-decay noise IR that models room acoustics.
 // Extracted to module scope so Exporter.ts can use it without importing AudioEngine.
 export function buildIR(ctx: BaseAudioContext, decay: number, size: number): AudioBuffer {
@@ -210,8 +212,7 @@ export class AudioEngine {
 
   async loadFile(file: File): Promise<void> {
     // Basic security checks before handing to AudioContext
-    const maxBytes = 300 * 1024 * 1024  // 300 MB cap
-    if (file.size > maxBytes) throw new Error('File is too large (max 300 MB)')
+    if (file.size > MAX_FILE_SIZE_BYTES) throw new Error(`File is too large (max ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB)`)
 
     await this.ensureContext()
     this.stop()

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19,6 +19,8 @@
   --teal: #00d4aa;
   --teal-dim: rgba(0, 212, 170, 0.15);
 
+  --error-color: #ff5f7e;
+
   --radius: 10px;
   --radius-sm: 6px;
 
@@ -263,6 +265,18 @@ body::after {
 .dropzone.loading {
   pointer-events: none;
   opacity: 0.7;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.dropzone.loading .dropzone-icon {
+  animation: spin 1s linear infinite;
+}
+
+.dropzone-content.error .dropzone-title {
+  color: var(--error-color);
 }
 
 /* The glass card centered in the full-page overlay */

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -440,13 +440,25 @@ export class App {
   }
 
   private async loadFile(file: File): Promise<void> {
+    const content = this.dropzone.querySelector<HTMLElement>('.dropzone-content')!
+    const title   = this.dropzone.querySelector<HTMLElement>('.dropzone-title')!
+
+    const showDropzoneError = (message: string): void => {
+      title.textContent = message
+      content.classList.add('error')
+      setTimeout(() => {
+        title.textContent = 'Drop your audio file here'
+        content.classList.remove('error')
+      }, 3000)
+    }
+
     if (file.type && !file.type.startsWith('audio/')) {
-      alert('Please drop an audio file.')
+      showDropzoneError('Please drop an audio file.')
       return
     }
 
     this.dropzone.classList.add('loading')
-    this.dropzone.querySelector('.dropzone-title')!.textContent = 'Decoding audio...'
+    title.textContent = 'Decoding audio...'
 
     try {
       await this.engine.loadFile(file)
@@ -487,8 +499,7 @@ export class App {
 
     } catch (err) {
       console.error('Failed to decode audio:', err)
-      alert('Could not decode this audio file. Please try a different format.')
-      this.dropzone.querySelector('.dropzone-title')!.textContent = 'Drop your audio file here'
+      showDropzoneError('Could not decode this file. Try a different format.')
     } finally {
       this.dropzone.classList.remove('loading')
     }


### PR DESCRIPTION
## Summary

- **#37** — Creates `public/_headers` for Cloudflare Pages with `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`
- **#39** — Adds `Permissions-Policy`, `Cross-Origin-Opener-Policy`, and `Cross-Origin-Resource-Policy` to the same `_headers` file; documents all 7 headers and rationale in `SECURITY.md`
- **#38** — Lifts file size cap to a named `MAX_FILE_SIZE_BYTES = 500 MB` constant in `AudioEngine.ts`; replaces all `alert()` dialogs with inline drop zone error messages (auto-clear after 3 s); adds a CSS spinner animation on the drop zone icon during `decodeAudioData`

Closes #37
Closes #38
Closes #39

## Test plan

- [ ] `npm run build` passes with zero TypeScript errors
- [ ] Drop a file larger than 500 MB — error appears inline in drop zone, clears after 3 s, no browser `alert()` dialog
- [ ] Drop a non-audio file — same inline error treatment, no `alert()`
- [ ] Drop a valid audio file — drop zone icon spins during decode, stops on success/failure
- [ ] Verify `public/_headers` is present in the `dist/` build output (Vite copies `public/` verbatim)
- [ ] On a Cloudflare Pages preview deployment, `curl -I <url>` should show all 7 security headers
- [ ] PWA service worker still registers and caches app shell (`connect-src 'self'` permits sw.js fetch calls)