### PR TITLE
fix(perf): stop stacking rAF loops when StarOverlay is paused

### DIFF
--- a/src/ui/StarOverlay.ts
+++ b/src/ui/StarOverlay.ts
@@ -128,7 +128,13 @@ export class StarOverlay {
   }
 
   private loop(now: number): void {
-    this.rafId = requestAnimationFrame((t) => this.loop(t))
+    // Only reschedule via rAF while playing. When paused, setInterval drives
+    // frames at ~15 fps and loop() must NOT re-arm rAF or multiple loops stack.
+    if (this.playing) {
+      this.rafId = requestAnimationFrame((t) => this.loop(t))
+    } else {
+      this.rafId = null
+    }
 
     if (this.lastTime < 0) this.lastTime = now
     const dt = Math.min(now - this.lastTime, 50)


### PR DESCRIPTION
setInterval called loop() which unconditionally scheduled a new rAF, spawning an extra full-speed loop every 67 ms. After a few seconds dozens of parallel loops caused severe UI lag.

Guard the rAF reschedule with a this.playing check so that when paused the setInterval drives frames and loop() does not re-arm itself.