### PR TITLE
fix(mobile): orb squish on rotation, smaller default, session reload, button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,9 @@
         <!-- Player HUD — shown after file loads, children use fixed positioning -->
         <div id="player" class="player" aria-hidden="true" style="display:none;opacity:0">
 
+          <!-- Help button: fixed top-right, accessible from anywhere in the player -->
+          <button id="helpBtn" class="btn btn-icon btn-help" aria-label="Show keyboard shortcuts" title="Keyboard shortcuts (?)">?</button>
+
           <!-- Top HUD: track info + preset strip -->
           <div class="player-top">
             <div class="track-info">
@@ -509,7 +512,6 @@
                 <button id="playlistShowBtn" class="btn-controls-show" aria-label="Show playlist">Playlist</button>
                 <button id="controlsShowBtn" class="btn-controls-show" aria-label="Show controls">Controls</button>
                 <button id="effectsShowBtn" class="btn-controls-show" aria-label="Show effects">Effects</button>
-                <button id="helpBtn" class="btn-controls-show btn-help" aria-label="Show keyboard shortcuts" title="Keyboard shortcuts (?)">?</button>
               </div>
             </div>
           </div>

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -216,6 +216,9 @@ export class AudioEngine {
 
     await this.ensureContext()
     this.stop()
+    // Release the old decoded buffer before allocating the new one so iOS
+    // doesn't hold both simultaneously and trigger a memory-pressure reload.
+    this.buffer = null
     const arrayBuffer = await file.arrayBuffer()
     this.buffer = await this.context!.decodeAudioData(arrayBuffer)
     this._startOffset = 0

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1118,7 +1118,7 @@ body.is-paused .btn-play {
      Row 2: total time + fullscreen + settings + Controls + Effects. */
   .transport-row {
     flex-wrap: wrap;
-    padding: 6px 12px 2px;
+    padding: 4px 10px 2px;
     gap: 4px 6px;
   }
 
@@ -1132,8 +1132,8 @@ body.is-paused .btn-play {
     flex-basis: 100%;
     margin-left: 0;
     justify-content: center;
-    gap: 8px;
-    padding-bottom: 4px;
+    gap: 6px;
+    padding-bottom: max(4px, env(safe-area-inset-bottom, 4px));
   }
 
   /* Landing page: scale down rings and text on mobile */
@@ -2400,12 +2400,16 @@ body.is-paused .site-footer {
   outline-offset: 2px;
 }
 
-/* ── Help button ────────────────────────────────────────────────────────── */
+/* ── Help button: fixed top-right corner ────────────────────────────────── */
 .btn-help {
+  position: fixed;
+  top: calc(12px + env(safe-area-inset-top, 0px));
+  right: calc(12px + env(safe-area-inset-right, 0px));
+  z-index: 55;
   font-size: 1rem;
   font-weight: 700;
   line-height: 1;
-  min-width: 28px;
+  min-width: 36px;
 }
 
 /* ── Keyboard shortcut help modal ───────────────────────────────────────── */

--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -508,9 +508,9 @@ export class AnomalySphere {
   private themeHueLock  = -1    // -1 = prism mode (free hue cycling), 0 = theme locked
   private bassPulse     = true
   private rotationSpeed = 1.0
-  // orbBaseScale starts slightly below 1.0 so the orb looks "small and contained"
+  // orbBaseScale starts noticeably below 1.0 so the orb looks small and contained
   // before the music kicks in; bass/kick energy drives it outward from there.
-  private orbBaseScale  = 0.72
+  private orbBaseScale  = 0.55
   private _8DEnabled    = false
   private _8DAngle      = 0    // current panner angle in radians, set by AudioEngine callback
   private particleCount = 500
@@ -725,6 +725,9 @@ export class AnomalySphere {
 
     // ── Start loop + defer first resize ─────────────────────────────────────
     window.addEventListener('resize', () => this.resize())
+    // orientationchange fires before the browser has applied the new viewport
+    // dimensions, so defer resize by 150 ms to let the layout settle first.
+    window.addEventListener('orientationchange', () => { setTimeout(() => this.resize(), 150) })
     this.loop()
     requestAnimationFrame(() => this.resize())
   }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -135,7 +135,7 @@ export class App {
     // Wire up mobile APIs: Media Session, Fullscreen, Vibration, and
     // AudioContext background recovery via visibilitychange.
     this._mobile = new MobileController(this.engine)
-    this._mobile.onExternalPlay  = () => { this.setPlayingState(true);  this.sphere?.start(); this.starOverlay.resume() }
+    this._mobile.onExternalPlay  = () => { this.setPlayingState(true);  this.sphere?.start(); this.starOverlay.resume(); void this._mobile.acquireWakeLock() }
     this._mobile.onExternalPause = () => { this.setPlayingState(false); this.sphere?.stop();  this.starOverlay.pause() }
     this._mobile.onExternalStop  = () => {
       this.setPlayingState(false)
@@ -144,6 +144,7 @@ export class App {
       this.sphere?.stop()
       this.starOverlay.pause()
       this._mobile.stopSilenceLoop()
+      this._mobile.releaseWakeLock()
     }
     const fsBtn = document.getElementById('fullscreenBtn') as HTMLButtonElement | null
     if (fsBtn) this._mobile.bindFullscreenBtn(fsBtn)
@@ -185,6 +186,7 @@ export class App {
       this.starOverlay.resume()
       this._mobile?.ensureSilenceLoop()
       this._mobile?.updatePlaybackState(true)
+      void this._mobile?.acquireWakeLock()
     }
   }
 
@@ -327,6 +329,9 @@ export class App {
       const next = this.currentTrackIndex + 1
       if (next < this.playlist.length) {
         void this.switchTrack(next, true)
+      } else {
+        // No more tracks — release the wake lock so the screen can sleep.
+        this._mobile?.releaseWakeLock()
       }
     }
     this.engine.onTimeUpdate = (current, duration) => {
@@ -380,6 +385,7 @@ export class App {
       this.sphere?.stop()
       this.starOverlay.pause()
       this._mobile?.stopSilenceLoop()
+      this._mobile?.releaseWakeLock()
     })
     this.rewindBtn.addEventListener('click', () => {
       this.engine.seek(Math.max(0, this.engine.currentTime - 5))
@@ -751,6 +757,7 @@ export class App {
       this._mobile.hapticPlay()
       this._mobile.updatePlaybackState(true)
       this._mobile.ensureSilenceLoop()
+      void this._mobile.acquireWakeLock()
     }
   }
 

--- a/src/ui/MobileController.ts
+++ b/src/ui/MobileController.ts
@@ -32,6 +32,23 @@ export class MobileController {
   // Reference to the engine's keepalive audio element (set after first play).
   private _silentAudio: HTMLAudioElement | null = null
 
+  // Screen Wake Lock — keeps the browser tab alive during extended playback.
+  // The sentinel is released automatically when the tab is hidden, so we
+  // re-acquire it each time the tab becomes visible and music is playing.
+  private _wakeLock: WakeLockSentinel | null = null
+
+  async acquireWakeLock(): Promise<void> {
+    if (!('wakeLock' in navigator)) return
+    try {
+      this._wakeLock = await navigator.wakeLock.request('screen')
+    } catch { /* denied or unsupported — non-fatal */ }
+  }
+
+  releaseWakeLock(): void {
+    this._wakeLock?.release().catch(() => {})
+    this._wakeLock = null
+  }
+
   private _onVisibilityChange = () => {
     if (document.visibilityState === 'hidden') {
       if (!IS_MOBILE_PLATFORM) return
@@ -48,6 +65,8 @@ export class MobileController {
       this._engine.resumeFromBackground()
       // Also restart the silence loop in case iOS paused the audio element
       if (this._engine.isPlaying) this.ensureSilenceLoop()
+      // Re-acquire wake lock — it is automatically released on tab hide.
+      if (this._engine.isPlaying) void this.acquireWakeLock()
       if ('mediaSession' in navigator) {
         navigator.mediaSession.playbackState =
           this._engine.isPlaying ? 'playing' : 'paused'
@@ -137,6 +156,7 @@ export class MobileController {
   destroy(): void {
     document.removeEventListener('visibilitychange', this._onVisibilityChange)
     this.stopSilenceLoop()
+    this.releaseWakeLock()
     if (!('mediaSession' in navigator)) return
     const actions: MediaSessionAction[] = ['play', 'pause', 'stop', 'seekto', 'previoustrack', 'nexttrack']
     for (const action of actions) {


### PR DESCRIPTION
## Summary

- **Orb squish on rotation** — `AnomalySphere` now registers an `orientationchange` listener that defers `resize()` by 150 ms, giving iOS/Android time to fully reflow before the camera Z-position is recalculated. Previously only `window.resize` was used, which fires before new viewport dimensions are settled on mobile.

- **Smaller default orb** — `orbBaseScale` default lowered from `0.72` → `0.55` so the orb starts noticeably smaller before music kicks in.

- **App reloads / session killed after 2+ min** — Two changes:
  - `AudioEngine.loadFile()` now nulls `this.buffer` before decoding the next track. Previously both the old decoded buffer and the new raw + decoded bytes were in memory simultaneously, creating 2–3× memory spikes on large files that iOS would respond to by killing the tab.
  - Added **Screen Wake Lock API** to `MobileController` — acquired on every play action, released on stop/end-of-playlist, and re-acquired when the tab regains visibility (wake lock is auto-released on tab hide). Prevents iOS from sleeping the tab during extended playback.

- **Bottom button spacing + help button moved** — `#helpBtn` is now `position: fixed` in the top-right corner (with `env(safe-area-inset-*` support for notched iPhones). Removed from `.transport-right` so the bottom row has more breathing room. Tightened mobile `transport-row` padding and `transport-right` gap accordingly.

## Test plan
- [ ] Rotate device while playing — orb should snap to correct size without squish
- [ ] Load a track — orb should start smaller than before
- [ ] Play a 2-track playlist, let it run 2+ minutes / auto-advance — session should survive
- [ ] Leave screen idle while playing — screen stays on (wake lock active)
- [ ] Help `?` button appears top-right on mobile; bottom transport row buttons are evenly spaced
- [ ] Desktop: no regressions — help button visible top-right, bottom bar unchanged