### PR TITLE
feat: unified sound drawer, preset visual params, iOS/mobile fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,164 +182,178 @@
             </div>
           </div>
 
-          <!-- Playlist drawer — right side, opens with "Playlist" button -->
-          <div id="playlistDrawer" class="controls-drawer controls-drawer--hidden">
+          <!-- Playlist drawer — right side -->
+          <div id="playlistDrawer" class="controls-drawer">
             <div class="controls-drawer-header">
               <span class="controls-drawer-title">Playlist</span>
               <span id="playlistCount" class="playlist-count">0 tracks</span>
               <button id="playlistCloseBtn" class="controls-drawer-btn" aria-label="Close playlist">&times;</button>
             </div>
-            <ol id="playlistList" class="playlist-list" aria-label="Track list" aria-live="polite"></ol>
+            <div class="playlist-search-wrap">
+              <input type="search" id="playlistSearch" class="playlist-search" placeholder="Search tracks…" autocomplete="off" aria-label="Search tracks" />
+            </div>
+            <div class="drawer-scroll-body">
+              <ol id="playlistList" class="playlist-list" aria-label="Track list" aria-live="polite"></ol>
+            </div>
             <div class="playlist-footer">
-              <button id="playlistAddBtn" class="btn-playlist-add" aria-label="Add more files to playlist">+ Add files</button>
+              <button id="playlistAddBtn"   class="btn-playlist-add"   aria-label="Add more files to playlist">+ Add files</button>
+              <button id="playlistClearBtn" class="btn-playlist-clear" aria-label="Clear all tracks">Clear all</button>
             </div>
           </div>
 
-          <!-- Audio Controls drawer — right side, opens with "Controls" button -->
-          <div id="controlsDrawer" class="controls-drawer controls-drawer--hidden">
-            <div class="controls-drawer-header">
-              <span class="controls-drawer-title">Controls</span>
-              <button id="controlsFloatBtn" class="controls-drawer-btn" title="Float panel" aria-label="Float panel">&#8862;</button>
-              <button id="controlsCloseBtn" class="controls-drawer-btn" title="Close panel" aria-label="Close panel">&times;</button>
+          <!-- Sound drawer — unified Audio + Effects tabs, right side -->
+          <div id="soundDrawer" class="sound-drawer">
+            <div class="sound-drawer-header">
+              <nav class="sound-tabs" role="tablist" aria-label="Sound settings tabs">
+                <button class="sound-tab sound-tab--active" data-tab="audio"   role="tab" aria-selected="true"  aria-controls="soundTab-audio">Audio</button>
+                <button class="sound-tab"                   data-tab="effects" role="tab" aria-selected="false" aria-controls="soundTab-effects">Effects</button>
+              </nav>
+              <button id="soundCloseBtn" class="controls-drawer-btn" aria-label="Close sound settings">&times;</button>
             </div>
 
-            <div class="controls">
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="speedSlider">Speed</label>
-                  <span class="value-badge" id="speedValue">1.00×</span>
+            <!-- Scrollable content area -->
+            <div class="drawer-scroll-body">
+            <!-- Audio tab -->
+            <div id="soundTab-audio" class="sound-tab-panel" role="tabpanel">
+              <div class="controls">
+                <div class="control-section-label">Playback</div>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="speedSlider">Speed</label>
+                    <span class="value-badge" id="speedValue">1.00×</span>
+                  </div>
+                  <input type="range" id="speedSlider" class="slider" min="50" max="170" value="100" step="1" aria-label="Playback speed" />
+                  <div class="slider-ticks"><span>0.50×</span><span>1.00×</span><span>1.70×</span></div>
                 </div>
-                <input type="range" id="speedSlider" class="slider" min="50" max="170" value="100" step="1" aria-label="Playback speed" />
-                <div class="slider-ticks">
-                  <span>0.50×</span><span>1.00×</span><span>1.70×</span>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="pitchSlider">Pitch</label>
+                    <span class="value-badge" id="pitchValue">0 st</span>
+                  </div>
+                  <input type="range" id="pitchSlider" class="slider slider--pitch" min="-12" max="12" value="0" step="1" aria-label="Pitch shift in semitones" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
                 </div>
-              </div>
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="pitchSlider">Pitch</label>
-                  <span class="value-badge" id="pitchValue">0 st</span>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="volumeSlider">Volume</label>
+                    <span class="value-badge" id="volumeValue">80%</span>
+                  </div>
+                  <input type="range" id="volumeSlider" class="slider slider--dim" min="0" max="100" value="80" step="1" aria-label="Volume" />
                 </div>
-                <input type="range" id="pitchSlider" class="slider slider--pitch" min="-12" max="12" value="0" step="1" aria-label="Pitch shift in semitones" />
-                <div class="slider-ticks">
-                  <span>-12</span><span>0</span><span>+12</span>
+
+                <div class="control-section-label">Reverb</div>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="reverbSlider">Mix</label>
+                    <span class="value-badge" id="reverbValue">20%</span>
+                  </div>
+                  <input type="range" id="reverbSlider" class="slider slider--teal" min="0" max="100" value="20" step="1" aria-label="Reverb mix" />
                 </div>
-              </div>
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="reverbSlider">Reverb Mix</label>
-                  <span class="value-badge" id="reverbValue">20%</span>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="decaySlider">Decay</label>
+                    <span class="value-badge" id="decayValue">2.5s</span>
+                  </div>
+                  <input type="range" id="decaySlider" class="slider slider--teal" min="5" max="80" value="25" step="1" aria-label="Reverb decay" />
                 </div>
-                <input type="range" id="reverbSlider" class="slider slider--teal" min="0" max="100" value="20" step="1" aria-label="Reverb mix" />
-              </div>
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="decaySlider">Decay</label>
-                  <span class="value-badge" id="decayValue">2.5s</span>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="roomSlider">Room Size</label>
+                    <span class="value-badge" id="roomValue">50%</span>
+                  </div>
+                  <input type="range" id="roomSlider" class="slider slider--teal" min="1" max="100" value="50" step="1" aria-label="Room size" />
                 </div>
-                <input type="range" id="decaySlider" class="slider slider--teal" min="5" max="80" value="25" step="1" aria-label="Reverb decay" />
-              </div>
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="roomSlider">Room Size</label>
-                  <span class="value-badge" id="roomValue">50%</span>
-                </div>
-                <input type="range" id="roomSlider" class="slider slider--teal" min="1" max="100" value="50" step="1" aria-label="Room size" />
-              </div>
-              <div class="control-group">
-                <div class="control-header">
-                  <label for="volumeSlider">Volume</label>
-                  <span class="value-badge" id="volumeValue">80%</span>
-                </div>
-                <input type="range" id="volumeSlider" class="slider slider--dim" min="0" max="100" value="80" step="1" aria-label="Volume" />
               </div>
             </div>
 
-          </div>
+            <!-- Effects tab -->
+            <div id="soundTab-effects" class="sound-tab-panel sound-tab-panel--hidden" role="tabpanel">
+              <div class="controls">
+                <div class="control-section-label">Equalizer</div>
+                <div class="control-group">
+                  <div class="control-header"><label for="eqLowSlider">Low</label><span class="value-badge value-badge--green" id="eqLowValue">0 dB</span></div>
+                  <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
+                <div class="control-group">
+                  <div class="control-header"><label for="eqMidSlider">Mid</label><span class="value-badge value-badge--green" id="eqMidValue">0 dB</span></div>
+                  <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
+                <div class="control-group">
+                  <div class="control-header"><label for="eqHighSlider">High</label><span class="value-badge value-badge--green" id="eqHighValue">0 dB</span></div>
+                  <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf" />
+                  <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
+                </div>
 
-          <!-- Effects drawer — right side, opens with "Effects" button -->
-          <div id="effectsDrawer" class="controls-drawer controls-drawer--hidden">
-            <div class="controls-drawer-header">
-              <span class="controls-drawer-title">Effects Chain</span>
-              <button id="effectsCloseBtn" class="controls-drawer-btn" title="Close panel" aria-label="Close panel">&times;</button>
-            </div>
-            <div class="controls">
-              <div class="control-group">
-                <div class="control-header"><label for="eqLowSlider">EQ Low</label><span class="value-badge value-badge--green" id="eqLowValue">0 dB</span></div>
-                <input type="range" id="eqLowSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ low shelf" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-              </div>
-              <div class="control-group">
-                <div class="control-header"><label for="eqMidSlider">EQ Mid</label><span class="value-badge value-badge--green" id="eqMidValue">0 dB</span></div>
-                <input type="range" id="eqMidSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ mid peak" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-              </div>
-              <div class="control-group">
-                <div class="control-header"><label for="eqHighSlider">EQ High</label><span class="value-badge value-badge--green" id="eqHighValue">0 dB</span></div>
-                <input type="range" id="eqHighSlider" class="slider slider--green" min="-12" max="12" value="0" step="0.5" aria-label="EQ high shelf" />
-                <div class="slider-ticks"><span>-12</span><span>0</span><span>+12</span></div>
-              </div>
-              <div class="control-group">
-                <div class="control-header"><label for="chorusRateSlider">Chorus Rate</label><span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span></div>
-                <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus rate" />
-                <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
-              </div>
-              <div class="control-group">
-                <div class="control-header"><label for="chorusDepthSlider">Chorus Depth</label><span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span></div>
-                <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
-              </div>
-              <div class="control-group">
-                <div class="control-header"><label for="satDriveSlider">Saturator</label><span class="value-badge value-badge--red" id="satDriveValue">0%</span></div>
-                <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Saturator" />
-                <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Saturated</span></div>
-              </div>
-              <div class="control-group control-group--8d">
-                <label class="toggle-row">
-                  <span class="toggle-label">
-                    <svg class="icon-headphones" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                      <path d="M3 18v-6a9 9 0 0 1 18 0v6"/>
-                      <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>
-                    </svg>
-                    8D Audio
-                  </span>
-                  <span class="toggle-wrap">
-                    <input type="checkbox" id="eightDToggle" class="toggle-input" aria-label="8D audio — headphones required" />
-                    <span class="toggle-track"></span>
-                  </span>
-                </label>
-                <p class="control-hint" id="eightDHint">Use headphones for the binaural effect</p>
-                <div class="control-header" id="eightDSpeedRow" style="display:none">
-                  <label for="eightDSpeedSlider">Rotation Speed</label>
-                  <span class="value-badge value-badge--purple" id="eightDSpeedValue">0.5 Hz</span>
+                <div class="control-section-label">Modulation</div>
+                <div class="control-group">
+                  <div class="control-header"><label for="chorusRateSlider">Chorus Rate</label><span class="value-badge value-badge--orange" id="chorusRateValue">0.8 Hz</span></div>
+                  <input type="range" id="chorusRateSlider" class="slider slider--orange" min="0.1" max="5" value="0.8" step="0.1" aria-label="Chorus rate" />
+                  <div class="slider-ticks"><span>0.1 Hz</span><span>2.5 Hz</span><span>5 Hz</span></div>
                 </div>
-                <input type="range" id="eightDSpeedSlider" class="slider slider--purple" min="1" max="20" value="5" step="1" aria-label="8D rotation speed" style="display:none" />
-                <div class="slider-ticks" id="eightDSpeedTicks" style="display:none"><span>Slow</span><span>0.5 Hz</span><span>Fast</span></div>
-              </div>
-              <div class="control-group control-group--hz">
-                <div class="control-header">
-                  <label>Hz Resonance</label>
-                  <span class="value-badge value-badge--indigo" id="hzValue">Off</span>
+                <div class="control-group">
+                  <div class="control-header"><label for="chorusDepthSlider">Chorus Depth</label><span class="value-badge value-badge--orange" id="chorusDepthValue">0%</span></div>
+                  <input type="range" id="chorusDepthSlider" class="slider slider--orange" min="0" max="100" value="0" step="1" aria-label="Chorus depth" />
                 </div>
-                <div class="btn-hz-group" role="group" aria-label="Hz frequency resonance">
-                  <button class="btn-hz btn-hz--active" data-hz="off"  title="No frequency boost"                                 aria-pressed="true">Off</button>
-                  <button class="btn-hz" data-hz="432" title="432 Hz — Natural tuning, relaxation &amp; harmony"        aria-pressed="false">432</button>
-                  <button class="btn-hz" data-hz="528" title="528 Hz — Love frequency, transformation"                  aria-pressed="false">528</button>
-                  <button class="btn-hz" data-hz="639" title="639 Hz — Relationship healing, emotional balance"         aria-pressed="false">639</button>
-                  <button class="btn-hz" data-hz="741" title="741 Hz — Expression, intuition &amp; mental clarity"     aria-pressed="false">741</button>
-                  <button class="btn-hz" data-hz="852" title="852 Hz — Spiritual awareness &amp; inner strength"       aria-pressed="false">852</button>
-                  <button class="btn-hz" data-hz="963" title="963 Hz — Divine connection &amp; enlightenment"          aria-pressed="false">963</button>
+                <div class="control-group">
+                  <div class="control-header"><label for="satDriveSlider">Saturator</label><span class="value-badge value-badge--red" id="satDriveValue">0%</span></div>
+                  <input type="range" id="satDriveSlider" class="slider slider--red" min="0" max="100" value="0" step="1" aria-label="Saturator" />
+                  <div class="slider-ticks"><span>Clean</span><span>Warm</span><span>Saturated</span></div>
                 </div>
-                <p class="control-hint" id="hzHint">Hover a frequency to learn more</p>
+
+                <div class="control-section-label">Spatial</div>
+                <div class="control-group control-group--8d">
+                  <label class="toggle-row">
+                    <span class="toggle-label">
+                      <svg class="icon-headphones" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M3 18v-6a9 9 0 0 1 18 0v6"/>
+                        <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>
+                      </svg>
+                      8D Audio
+                    </span>
+                    <span class="toggle-wrap">
+                      <input type="checkbox" id="eightDToggle" class="toggle-input" aria-label="8D audio — headphones required" />
+                      <span class="toggle-track"></span>
+                    </span>
+                  </label>
+                  <p class="control-hint" id="eightDHint">Use headphones for the binaural effect</p>
+                  <div class="control-header" id="eightDSpeedRow" style="display:none">
+                    <label for="eightDSpeedSlider">Rotation Speed</label>
+                    <span class="value-badge value-badge--purple" id="eightDSpeedValue">0.5 Hz</span>
+                  </div>
+                  <input type="range" id="eightDSpeedSlider" class="slider slider--purple" min="1" max="20" value="5" step="1" aria-label="8D rotation speed" style="display:none" />
+                  <div class="slider-ticks" id="eightDSpeedTicks" style="display:none"><span>Slow</span><span>0.5 Hz</span><span>Fast</span></div>
+                </div>
+                <div class="control-group control-group--hz">
+                  <div class="control-header">
+                    <label>Hz Resonance</label>
+                    <span class="value-badge value-badge--indigo" id="hzValue">Off</span>
+                  </div>
+                  <div class="btn-hz-group" role="group" aria-label="Hz frequency resonance">
+                    <button class="btn-hz btn-hz--active" data-hz="off"  title="No frequency boost"                                  aria-pressed="true">Off</button>
+                    <button class="btn-hz" data-hz="432" title="432 Hz — Natural tuning, relaxation &amp; harmony"         aria-pressed="false">432</button>
+                    <button class="btn-hz" data-hz="528" title="528 Hz — Love frequency, transformation"                   aria-pressed="false">528</button>
+                    <button class="btn-hz" data-hz="639" title="639 Hz — Relationship healing, emotional balance"          aria-pressed="false">639</button>
+                    <button class="btn-hz" data-hz="741" title="741 Hz — Expression, intuition &amp; mental clarity"      aria-pressed="false">741</button>
+                    <button class="btn-hz" data-hz="852" title="852 Hz — Spiritual awareness &amp; inner strength"        aria-pressed="false">852</button>
+                    <button class="btn-hz" data-hz="963" title="963 Hz — Divine connection &amp; enlightenment"           aria-pressed="false">963</button>
+                  </div>
+                  <p class="control-hint" id="hzHint">Hover a frequency to learn more</p>
+                </div>
               </div>
             </div>
+            </div><!-- /.drawer-scroll-body -->
           </div>
 
           <!-- Visual Settings drawer — left side, opens with gear button -->
-          <div id="settingsDrawer" class="settings-drawer settings-drawer--hidden">
+          <div id="settingsDrawer" class="settings-drawer">
             <div class="controls-drawer-header">
-              <span class="controls-drawer-title">Visual Settings</span>
+              <span class="controls-drawer-title">Visual</span>
               <button id="settingsCloseBtn" class="controls-drawer-btn" title="Close" aria-label="Close">&times;</button>
             </div>
 
+            <div class="drawer-scroll-body">
             <!-- Color Themes -->
             <div class="settings-themes">
               <div class="settings-label">Color Theme</div>
@@ -365,101 +379,85 @@
               </div>
             </div>
 
-            <!-- Orb options -->
-            <details class="controls-section" open>
-              <summary class="controls-section-header">
-                <span>Orb</span>
-                <span class="controls-section-hint">Shape · Motion · Effects</span>
-              </summary>
-              <div class="controls">
-                <div class="control-group">
-                  <div class="control-header"><label for="orbReactivitySlider">Reactivity</label><span class="value-badge" id="orbReactivityValue">80%</span></div>
-                  <input type="range" id="orbReactivitySlider" class="slider" min="0" max="100" value="80" step="1" aria-label="Orb reactivity" />
-                  <div class="slider-ticks"><span>Calm</span><span>Normal</span><span>Wild</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="orbGlowSlider">Glow</label><span class="value-badge" id="orbGlowValue">100%</span></div>
-                  <input type="range" id="orbGlowSlider" class="slider" min="0" max="150" value="100" step="1" aria-label="Orb glow intensity" />
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="orbSizeSlider">Size</label><span class="value-badge" id="orbSizeValue">100%</span></div>
-                  <input type="range" id="orbSizeSlider" class="slider" min="40" max="180" value="100" step="1" aria-label="Orb size" />
-                  <div class="slider-ticks"><span>Small</span><span>Normal</span><span>Large</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="rotationSpeedSlider">Rotation</label><span class="value-badge" id="rotationSpeedValue">1.0×</span></div>
-                  <input type="range" id="rotationSpeedSlider" class="slider" min="0" max="200" value="100" step="1" aria-label="Orb rotation speed" />
-                  <div class="slider-ticks"><span>Still</span><span>1×</span><span>Fast</span></div>
-                </div>
-                <div class="control-group">
-                  <div class="control-header"><label for="particleCountSlider">Particles</label><span class="value-badge" id="particleCountValue">500</span></div>
-                  <input type="range" id="particleCountSlider" class="slider" min="0" max="2000" value="500" step="50" aria-label="Particle count" />
-                  <div class="slider-ticks"><span>None</span><span>500</span><span>2000</span></div>
-                </div>
-                <div class="control-group">
-                  <label class="toggle-row">
-                    <span class="toggle-label">Bass Pulse</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="bassPulseToggle" class="toggle-input" checked aria-label="Bass pulse" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                  <label class="toggle-row">
-                    <span class="toggle-label">Wireframe</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="wireframeToggle" class="toggle-input" checked aria-label="Wireframe mode" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                </div>
-                <div class="control-group">
-                  <div class="control-group-label">Orb Effects</div>
-                  <label class="toggle-row">
-                    <span class="toggle-label">Lightning</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="lightningToggle" class="toggle-input" checked aria-label="Lightning tendrils" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                  <label class="toggle-row">
-                    <span class="toggle-label">Crack Veins</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="crackToggle" class="toggle-input" checked aria-label="Surface crack veins" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                  <label class="toggle-row">
-                    <span class="toggle-label">Crystallize on Pause</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="crystalToggle" class="toggle-input" checked aria-label="Pause crystallization" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                  <label class="toggle-row">
-                    <span class="toggle-label">Glitch</span>
-                    <span class="toggle-wrap">
-                      <input type="checkbox" id="glitchToggle" class="toggle-input" aria-label="Glitch corruption" />
-                      <span class="toggle-track"></span>
-                    </span>
-                  </label>
-                </div>
+            <div class="controls">
+              <div class="control-section-label">Orb</div>
+              <div class="control-group">
+                <div class="control-header"><label for="orbReactivitySlider">Reactivity</label><span class="value-badge" id="orbReactivityValue">80%</span></div>
+                <input type="range" id="orbReactivitySlider" class="slider" min="0" max="100" value="80" step="1" aria-label="Orb reactivity" />
+                <div class="slider-ticks"><span>Calm</span><span>Normal</span><span>Wild</span></div>
               </div>
-            </details>
+              <div class="control-group">
+                <div class="control-header"><label for="orbGlowSlider">Glow</label><span class="value-badge" id="orbGlowValue">100%</span></div>
+                <input type="range" id="orbGlowSlider" class="slider" min="0" max="150" value="100" step="1" aria-label="Orb glow intensity" />
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="orbSizeSlider">Size</label><span class="value-badge" id="orbSizeValue">100%</span></div>
+                <input type="range" id="orbSizeSlider" class="slider" min="40" max="180" value="100" step="1" aria-label="Orb size" />
+                <div class="slider-ticks"><span>Small</span><span>Normal</span><span>Large</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="rotationSpeedSlider">Rotation</label><span class="value-badge" id="rotationSpeedValue">1.0×</span></div>
+                <input type="range" id="rotationSpeedSlider" class="slider" min="0" max="200" value="100" step="1" aria-label="Orb rotation speed" />
+                <div class="slider-ticks"><span>Still</span><span>1×</span><span>Fast</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="particleCountSlider">Particles</label><span class="value-badge" id="particleCountValue">500</span></div>
+                <input type="range" id="particleCountSlider" class="slider" min="0" max="2000" value="500" step="50" aria-label="Particle count" />
+                <div class="slider-ticks"><span>None</span><span>500</span><span>2000</span></div>
+              </div>
+              <div class="control-group">
+                <div class="control-header"><label for="starsSlider">Stars</label><span class="value-badge" id="starsValue">70%</span></div>
+                <input type="range" id="starsSlider" class="slider" min="0" max="100" value="70" step="1" aria-label="Star brightness" />
+                <div class="slider-ticks"><span>Off</span><span>Normal</span><span>Bright</span></div>
+              </div>
 
-            <!-- Stars -->
-            <details class="controls-section">
-              <summary class="controls-section-header">
-                <span>Stars</span>
-                <span class="controls-section-hint">Brightness · Twinkle</span>
-              </summary>
-              <div class="controls">
-                <div class="control-group">
-                  <div class="control-header"><label for="starsSlider">Brightness</label><span class="value-badge" id="starsValue">70%</span></div>
-                  <input type="range" id="starsSlider" class="slider" min="0" max="100" value="70" step="1" aria-label="Star brightness" />
-                  <div class="slider-ticks"><span>Off</span><span>Normal</span><span>Bright</span></div>
-                </div>
+              <div class="control-section-label">Effects</div>
+              <div class="control-group">
+                <label class="toggle-row">
+                  <span class="toggle-label">Wireframe</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="wireframeToggle" class="toggle-input" checked aria-label="Wireframe mode" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-label">Bass Pulse</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="bassPulseToggle" class="toggle-input" checked aria-label="Bass pulse" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-label">Lightning</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="lightningToggle" class="toggle-input" checked aria-label="Lightning tendrils" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-label">Crack Veins</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="crackToggle" class="toggle-input" checked aria-label="Surface crack veins" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-label">Crystallize on Pause</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="crystalToggle" class="toggle-input" checked aria-label="Pause crystallization" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-label">Glitch</span>
+                  <span class="toggle-wrap">
+                    <input type="checkbox" id="glitchToggle" class="toggle-input" aria-label="Glitch corruption" />
+                    <span class="toggle-track"></span>
+                  </span>
+                </label>
               </div>
-            </details>
+            </div>
+            </div><!-- /.drawer-scroll-body -->
           </div>
 
           <!-- Bottom HUD: waveform + transport -->
@@ -516,8 +514,7 @@
                   </svg>
                 </button>
                 <button id="playlistShowBtn" class="btn-controls-show" aria-label="Show playlist">Playlist</button>
-                <button id="controlsShowBtn" class="btn-controls-show" aria-label="Show controls">Controls</button>
-                <button id="effectsShowBtn" class="btn-controls-show" aria-label="Show effects">Effects</button>
+                <button id="soundShowBtn" class="btn-controls-show" aria-label="Sound settings" title="Audio &amp; Effects">Sound</button>
               </div>
             </div>
           </div>
@@ -538,23 +535,125 @@
       </a>
     </footer>
 
-    <!-- Keyboard shortcut help overlay — opened with ? key or help button -->
-    <dialog id="help-modal" aria-modal="true" aria-label="Keyboard shortcuts">
+    <!-- Help modal — opened with ? key or help button -->
+    <dialog id="help-modal" aria-modal="true" aria-label="Help">
       <div class="help-modal-inner">
         <div class="help-modal-header">
-          <h2 class="help-modal-title">Keyboard Shortcuts</h2>
-          <button id="helpCloseBtn" class="help-modal-close" aria-label="Close shortcuts">&times;</button>
+          <nav class="help-tabs" role="tablist" aria-label="Help sections">
+            <button class="help-tab help-tab--active" data-tab="shortcuts" role="tab" aria-selected="true"  aria-controls="helpTab-shortcuts">Shortcuts</button>
+            <button class="help-tab"                  data-tab="guide"     role="tab" aria-selected="false" aria-controls="helpTab-guide">Feature Guide</button>
+            <button class="help-tab"                  data-tab="about"     role="tab" aria-selected="false" aria-controls="helpTab-about">About</button>
+          </nav>
+          <button id="helpCloseBtn" class="controls-drawer-btn" aria-label="Close help">&times;</button>
         </div>
-        <dl class="shortcut-grid">
-          <div class="shortcut-row"><dt><kbd>Space</kbd></dt><dd>Play / Pause</dd></div>
-          <div class="shortcut-row"><dt><kbd>L</kbd></dt><dd>Toggle loop</dd></div>
-          <div class="shortcut-row"><dt><kbd>S</kbd></dt><dd>Stop &amp; rewind</dd></div>
-          <div class="shortcut-row"><dt><kbd>&#8592;</kbd></dt><dd>Rewind 5 s</dd></div>
-          <div class="shortcut-row"><dt><kbd>&#8594;</kbd></dt><dd>Forward 5 s</dd></div>
-          <div class="shortcut-row"><dt><kbd>?</kbd></dt><dd>Show this help</dd></div>
-        </dl>
+
+        <!-- Shortcuts tab -->
+        <div id="helpTab-shortcuts" class="help-tab-panel" role="tabpanel">
+          <div class="shortcut-sections">
+            <div class="shortcut-section">
+              <div class="shortcut-section-label">Playback</div>
+              <dl class="shortcut-grid">
+                <div class="shortcut-row"><dt><kbd>Space</kbd></dt><dd>Play / Pause</dd></div>
+                <div class="shortcut-row"><dt><kbd>S</kbd></dt><dd>Stop &amp; rewind</dd></div>
+                <div class="shortcut-row"><dt><kbd>L</kbd></dt><dd>Toggle loop</dd></div>
+                <div class="shortcut-row"><dt><kbd>F</kbd></dt><dd>Fullscreen</dd></div>
+              </dl>
+            </div>
+            <div class="shortcut-section">
+              <div class="shortcut-section-label">Navigation</div>
+              <dl class="shortcut-grid">
+                <div class="shortcut-row"><dt><kbd>&#8592;</kbd></dt><dd>Rewind 5s</dd></div>
+                <div class="shortcut-row"><dt><kbd>&#8594;</kbd></dt><dd>Forward 5s</dd></div>
+                <div class="shortcut-row"><dt><kbd>N</kbd></dt><dd>Next track</dd></div>
+                <div class="shortcut-row"><dt><kbd>P</kbd></dt><dd>Previous track</dd></div>
+              </dl>
+            </div>
+            <div class="shortcut-section">
+              <div class="shortcut-section-label">Volume</div>
+              <dl class="shortcut-grid">
+                <div class="shortcut-row"><dt><kbd>[</kbd></dt><dd>Volume &minus;10%</dd></div>
+                <div class="shortcut-row"><dt><kbd>]</kbd></dt><dd>Volume +10%</dd></div>
+              </dl>
+            </div>
+            <div class="shortcut-section">
+              <div class="shortcut-section-label">Presets</div>
+              <dl class="shortcut-grid">
+                <div class="shortcut-row"><dt><kbd>1</kbd></dt><dd>Lo-Fi</dd></div>
+                <div class="shortcut-row"><dt><kbd>2</kbd></dt><dd>Vaporwave</dd></div>
+                <div class="shortcut-row"><dt><kbd>3</kbd></dt><dd>Ambient</dd></div>
+                <div class="shortcut-row"><dt><kbd>4</kbd></dt><dd>Hyperpop</dd></div>
+                <div class="shortcut-row"><dt><kbd>5</kbd></dt><dd>Custom</dd></div>
+              </dl>
+            </div>
+            <div class="shortcut-section">
+              <div class="shortcut-section-label">Other</div>
+              <dl class="shortcut-grid">
+                <div class="shortcut-row"><dt><kbd>?</kbd></dt><dd>Show this help</dd></div>
+              </dl>
+            </div>
+          </div>
+        </div>
+
+        <!-- Feature Guide tab -->
+        <div id="helpTab-guide" class="help-tab-panel help-tab-panel--hidden" role="tabpanel">
+          <div class="guide-grid">
+            <div class="guide-section">
+              <div class="guide-section-title">Audio Controls</div>
+              <dl class="guide-list">
+                <div class="guide-row"><dt>Speed</dt><dd>Slows or speeds up playback (0.5× – 1.7×) without changing pitch.</dd></div>
+                <div class="guide-row"><dt>Pitch</dt><dd>Shifts pitch up or down by semitones while keeping tempo constant.</dd></div>
+                <div class="guide-row"><dt>Volume</dt><dd>Master output level.</dd></div>
+                <div class="guide-row"><dt>Reverb Mix</dt><dd>Wet/dry blend of the convolution reverb effect.</dd></div>
+                <div class="guide-row"><dt>Decay</dt><dd>How long the reverb tail rings out (0.5s – 8s).</dd></div>
+                <div class="guide-row"><dt>Room Size</dt><dd>Virtual room size — affects reverb diffusion and spaciousness.</dd></div>
+                <div class="guide-row"><dt>EQ</dt><dd>Three-band equalizer (low shelf, mid peak, high shelf) ±12 dB each.</dd></div>
+                <div class="guide-row"><dt>Chorus</dt><dd>Rate controls modulation speed; Depth controls intensity of the shimmer.</dd></div>
+                <div class="guide-row"><dt>Saturator</dt><dd>Adds harmonic distortion — from subtle warmth to heavy drive.</dd></div>
+                <div class="guide-row"><dt>8D Audio</dt><dd>Binaural panning that rotates the audio around your head. Use headphones.</dd></div>
+                <div class="guide-row"><dt>Hz Resonance</dt><dd>Applies a solfeggio frequency tone underneath the track.</dd></div>
+              </dl>
+            </div>
+            <div class="guide-section">
+              <div class="guide-section-title">Visual Effects</div>
+              <dl class="guide-list">
+                <div class="guide-row"><dt>Wireframe</dt><dd>Renders only the orb's mesh edges as glowing lines instead of a solid surface.</dd></div>
+                <div class="guide-row"><dt>Bass Pulse</dt><dd>Orb scales up on every kick drum hit.</dd></div>
+                <div class="guide-row"><dt>Lightning</dt><dd>Electric arc bolts that spark from the orb surface on beats.</dd></div>
+                <div class="guide-row"><dt>Crack Veins</dt><dd>Blazing fracture lines that appear on heavy bass hits.</dd></div>
+                <div class="guide-row"><dt>Crystallize</dt><dd>Freezes and ices the orb geometry when playback is paused.</dd></div>
+                <div class="guide-row"><dt>Glitch</dt><dd>Digital corruption artifacts — vertex displacement and color noise.</dd></div>
+                <div class="guide-row"><dt>Reactivity</dt><dd>How aggressively the orb responds to the audio — low for calm visuals.</dd></div>
+                <div class="guide-row"><dt>Glow</dt><dd>Bloom post-processing intensity around the orb.</dd></div>
+                <div class="guide-row"><dt>Particles</dt><dd>Number of dust motes orbiting the sphere.</dd></div>
+                <div class="guide-row"><dt>Stars</dt><dd>Brightness and twinkle intensity of the background star field.</dd></div>
+              </dl>
+            </div>
+          </div>
+        </div>
+
+        <!-- About tab -->
+        <div id="helpTab-about" class="help-tab-panel help-tab-panel--hidden" role="tabpanel">
+          <div class="about-content">
+            <div class="about-logo">A N O M A L Y</div>
+            <div class="about-version">v2.2.0</div>
+            <p class="about-desc">A browser-based lo-fi music visualizer with real-time audio effects and a reactive 3D orb. Drop any audio file and tune it to your vibe.</p>
+            <div class="about-stack-label">Built with</div>
+            <div class="about-stack">
+              <span>Three.js</span>
+              <span>Web Audio API</span>
+              <span>Tailwind v4</span>
+              <span>TypeScript</span>
+              <span>Vite</span>
+            </div>
+            <a href="https://github.com/gurvinny" target="_blank" rel="noopener noreferrer" class="about-github">github.com/gurvinny</a>
+          </div>
+        </div>
+
       </div>
     </dialog>
+
+    <!-- Mobile drawer backdrop — tap to close any open drawer on phones -->
+    <div id="drawerBackdrop" class="drawer-backdrop"></div>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "slo-fi",
       "version": "2.0.0",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.2",
+        "ogl": "^1.0.11",
+        "tailwindcss": "^4.2.2",
         "three": "^0.183.2"
       },
       "devDependencies": {
@@ -27,7 +30,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
       "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -39,7 +41,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -50,18 +51,61 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -78,7 +122,6 @@
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
       "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -91,7 +134,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -108,7 +150,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -125,7 +166,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -142,7 +182,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -159,7 +198,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -176,7 +214,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -193,7 +230,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -210,7 +246,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -227,7 +262,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,7 +278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -261,7 +294,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,7 +310,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,7 +326,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -312,7 +342,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,7 +358,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -343,8 +371,276 @@
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
       "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -357,7 +653,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -405,17 +700,28 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -440,7 +746,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -451,11 +756,25 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -488,7 +807,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -509,7 +827,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -530,7 +847,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -551,7 +867,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -572,7 +887,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -593,7 +907,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -614,7 +927,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -635,7 +947,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -656,7 +967,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -677,7 +987,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -698,7 +1007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -712,6 +1020,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/meshoptimizer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
@@ -723,7 +1040,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -738,18 +1054,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ogl/-/ogl-1.0.11.tgz",
+      "integrity": "sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==",
+      "license": "Unlicense"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -762,7 +1082,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -791,7 +1110,6 @@
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
       "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.120.0",
@@ -825,10 +1143,28 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/three": {
@@ -841,7 +1177,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -858,7 +1193,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -880,7 +1214,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "vite": "^8.0.1"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.2",
+    "ogl": "^1.0.11",
+    "tailwindcss": "^4.2.2",
     "three": "^0.183.2"
   }
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,0 +1,46 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// DEFAULT SETTINGS
+// Edit this file to change what Slo-Fi starts with on a fresh load.
+// Saved user settings (localStorage) will still override these on return visits.
+// To reset a user back to these values: clear site data / localStorage.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const DEFAULTS = {
+
+  // ── Color Theme ─────────────────────────────────────────────────────────────
+  // 'prism'  — fully audio-reactive hue cycling (recommended)
+  // 'void'   — deep purple / indigo
+  // 'neon'   — electric cyan / magenta
+  // 'mono'   — desaturated silver / white
+  // 'ember'  — warm orange / red
+  colorTheme: 'prism' as 'prism' | 'void' | 'neon' | 'mono' | 'ember',
+
+  // ── Audio ────────────────────────────────────────────────────────────────────
+  speed:          1.00,   // playback rate  [0.50 – 1.70]
+  pitch:          0,      // semitones      [-12 – +12]
+  volume:         0.80,   // master volume  [0.00 – 1.00]
+
+  // ── Reverb ───────────────────────────────────────────────────────────────────
+  reverbMix:      0.20,   // wet/dry mix    [0.00 – 1.00]
+  reverbDecay:    2.5,    // tail length    [0.50 – 8.00] seconds
+  reverbRoomSize: 0.50,   // room size      [0.00 – 1.00]
+
+  // ── Orb Visuals ──────────────────────────────────────────────────────────────
+  reactivity:     0.80,   // beat response  [0.00 – 1.00]
+  glow:           1.00,   // bloom amount   [0.00 – 1.50]
+  orbSize:        1.00,   // sphere scale   [0.40 – 1.80]
+  rotationSpeed:  1.00,   // spin rate      [0.00 – 2.00]
+  stars:          0.70,   // star field     [0.00 – 1.00]
+  particleCount:  500,    // particle cloud [0 – 2000], step 50
+
+  // ── Effect Toggles ───────────────────────────────────────────────────────────
+  wireframe:  true,   // wireframe mesh overlay
+  bassPulse:  true,   // bass-reactive size pulsing
+  lightning:  true,   // electric arc bolts
+  crack:      true,   // fracture vein flashes on bass hits
+  crystal:    true,   // icy crystallize effect when paused
+  glitch:     false,  // digital glitch distortion
+
+}
+
+export type Defaults = typeof DEFAULTS

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,72 +1,170 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// PRESETS
+// Each preset is a named sound/visual profile selectable from the UI.
+//
+// HOW TO EDIT
+//   • Change any value and save — Vite hot-reloads instantly.
+//   • Add a new preset by copying an existing block and giving it a unique id.
+//   • The id must be lowercase, no spaces (used internally).
+//   • The name is what appears in the UI.
+//   • visual is optional — omit any field to inherit from DEFAULTS (defaults.ts).
+//
+// AUDIO RANGES (params)
+//   playbackRate    0.50 – 1.70   (1.0 = normal speed)
+//   reverbMix       0.00 – 1.00   (0 = dry, 1 = full wet)
+//   reverbDecay     0.50 – 8.00   seconds
+//   reverbRoomSize  0.00 – 1.00
+//   volume          0.00 – 1.00
+//   eq.low/mid/high -12 – +12     dB
+//   chorus.rate     0.10 – 5.00   Hz
+//   chorus.depth    0.00 – 1.00
+//   saturationDrive 0.00 – 1.00
+//   pitchSemitones  -12 – +12     (0 = no shift)
+//   hzFrequency     432 | 528 | 639 | 741 | 852 | 963 | null (off)
+//
+// VISUAL RANGES (visual)
+//   reactivity      0.00 – 1.00
+//   glow            0.00 – 1.50
+//   orbSize         0.40 – 1.80
+//   rotationSpeed   0.00 – 2.00
+//   stars           0.00 – 1.00
+//   particleCount   0 – 2000
+//   wireframe / bassPulse / lightning / crack / crystal / glitch: true | false
+//
+// COLOR THEMES
+//   'prism'  — audio-reactive hue cycling
+//   'void'   — deep purple / indigo
+//   'neon'   — electric cyan / magenta
+//   'mono'   — desaturated silver / white
+//   'ember'  — warm orange / red
+// ─────────────────────────────────────────────────────────────────────────────
+
 import type { PresetDefinition } from './types'
 
 export const PRESETS: PresetDefinition[] = [
+
+  // ── Lo-Fi ───────────────────────────────────────────────────────────────────
+  // Dusty, tape-worn. Heavy low-shelf boost, high-cut, slowed to 78%.
+  // Cranked room reverb makes everything feel basement-recorded.
   {
-    id: 'lofi',
-    name: 'Lo-Fi',
+    id:    'lofi',
+    name:  'Lo-Fi',
     theme: 'void',
     params: {
-      playbackRate: 0.78,
-      reverbMix: 0.47,
-      reverbDecay: 2.5,
-      reverbRoomSize: 0.68,
-      volume: 0.80,
-      eq: { low: 3, mid: -1, high: -5 },
-      chorus: { rate: 0, depth: 0 },
+      playbackRate:    0.78,
+      reverbMix:       0.47,
+      reverbDecay:     2.5,
+      reverbRoomSize:  0.68,
+      volume:          0.80,
+      eq:              { low: 3, mid: -1, high: -5 },
+      chorus:          { rate: 0, depth: 0 },
       saturationDrive: 0,
-      hzFrequency: null,
-      pitchSemitones: 0,
+      hzFrequency:     null,
+      pitchSemitones:  0,
+    },
+    visual: {
+      reactivity:    0.65,
+      glow:          0.80,
+      rotationSpeed: 0.60,
+      wireframe:     true,
+      lightning:     false,
+      crack:         false,
+      crystal:       true,
     },
   },
+
+  // ── Vaporwave ────────────────────────────────────────────────────────────────
+  // Sun-bleached and dreamy. Heavily slowed with a long wet reverb tail.
+  // Bright EQ high boost for that hazy VHS shimmer.
   {
-    id: 'vaporwave',
-    name: 'Vaporwave',
+    id:    'vaporwave',
+    name:  'Vaporwave',
     theme: 'neon',
     params: {
-      playbackRate: 0.69,
-      reverbMix: 0.74,
-      reverbDecay: 3.3,
-      reverbRoomSize: 0.52,
-      volume: 0.80,
-      eq: { low: 1.5, mid: 1, high: 2 },
-      chorus: { rate: 0.2, depth: 0 },
+      playbackRate:    0.69,
+      reverbMix:       0.74,
+      reverbDecay:     3.3,
+      reverbRoomSize:  0.52,
+      volume:          0.80,
+      eq:              { low: 1.5, mid: 1, high: 2 },
+      chorus:          { rate: 0.2, depth: 0 },
       saturationDrive: 0,
-      hzFrequency: null,
-      pitchSemitones: 0,
+      hzFrequency:     null,
+      pitchSemitones:  0,
+    },
+    visual: {
+      reactivity:    0.70,
+      glow:          1.20,
+      rotationSpeed: 0.75,
+      stars:         0.90,
+      wireframe:     true,
+      lightning:     true,
+      crack:         false,
     },
   },
+
+  // ── Ambient ──────────────────────────────────────────────────────────────────
+  // Slow drift. Maximum reverb decay for infinite pad-like tails.
+  // 432 Hz tuning for a warm, natural feel. Mid scoop for space.
   {
-    id: 'ambient',
-    name: 'Ambient',
+    id:    'ambient',
+    name:  'Ambient',
     theme: 'mono',
     params: {
-      playbackRate: 0.65,
-      reverbMix: 0.70,
-      reverbDecay: 4.4,
-      reverbRoomSize: 0.81,
-      volume: 0.75,
-      eq: { low: 0, mid: -3, high: -2 },
-      chorus: { rate: 0.5, depth: 0.10 },
+      playbackRate:    0.65,
+      reverbMix:       0.70,
+      reverbDecay:     4.4,
+      reverbRoomSize:  0.81,
+      volume:          0.75,
+      eq:              { low: 0, mid: -3, high: -2 },
+      chorus:          { rate: 0.5, depth: 0.10 },
       saturationDrive: 0,
-      hzFrequency: 432,
-      pitchSemitones: 0,
+      hzFrequency:     432,
+      pitchSemitones:  0,
+    },
+    visual: {
+      reactivity:    0.45,
+      glow:          0.90,
+      orbSize:       1.10,
+      rotationSpeed: 0.40,
+      stars:         1.00,
+      particleCount: 800,
+      wireframe:     true,
+      lightning:     false,
+      crack:         false,
+      glitch:        false,
     },
   },
+
+  // ── Hyperpop ─────────────────────────────────────────────────────────────────
+  // Sped-up and chaotic. Saturation drive, scooped mids, and a tight room.
+  // High reactivity and crack veins for maximum visual aggression.
   {
-    id: 'hyperpop',
-    name: 'Hyperpop',
+    id:    'hyperpop',
+    name:  'Hyperpop',
     theme: 'ember',
     params: {
-      playbackRate: 1.25,
-      reverbMix: 0.27,
-      reverbDecay: 1.7,
-      reverbRoomSize: 0.59,
-      volume: 0.80,
-      eq: { low: 1, mid: -3.5, high: 1 },
-      chorus: { rate: 0.8, depth: 0.08 },
+      playbackRate:    1.25,
+      reverbMix:       0.27,
+      reverbDecay:     1.7,
+      reverbRoomSize:  0.59,
+      volume:          0.80,
+      eq:              { low: 1, mid: -3.5, high: 1 },
+      chorus:          { rate: 0.8, depth: 0.08 },
       saturationDrive: 0.07,
-      hzFrequency: null,
-      pitchSemitones: 0,
+      hzFrequency:     null,
+      pitchSemitones:  0,
+    },
+    visual: {
+      reactivity:    1.00,
+      glow:          1.40,
+      rotationSpeed: 1.60,
+      particleCount: 1200,
+      wireframe:     false,
+      lightning:     true,
+      crack:         true,
+      glitch:        true,
     },
   },
+
 ]

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,86 +1,158 @@
-/* ── Design tokens ─────────────────────────────────────────────────────── */
-:root {
-  --bg: #080810;
-  --surface: #0f0f1a;
-  --surface-2: #141424;
-  --surface-3: #1a1a2e;
-  --border: #1e1e32;
-  --border-2: #28283d;
+/* ── Tailwind v4 — Vite-native, zero PostCSS config ────────────────────── */
+@import "tailwindcss";
 
-  --text: #e2e2f0;
-  --text-dim: #8888a8;
-  --text-muted: #44445a;
+/* ── Design tokens → Tailwind theme ────────────────────────────────────── */
+/* All @theme variables become both CSS custom props AND Tailwind utilities:
+   e.g. --color-accent → `bg-accent`, `text-accent`, `border-accent` etc.
+   Dynamic JS-updated vars (--aurora-bass, --ui-bass) stay in @layer base. */
+@theme {
+  --color-bg:           #080810;
+  --color-surface:      #0f0f1a;
+  --color-surface-2:    #141424;
+  --color-surface-3:    #1a1a2e;
+  --color-border:       #1e1e32;
+  --color-border-2:     #28283d;
 
-  --accent: #9b6dff;
-  --accent-dim: rgba(155, 109, 255, 0.18);
-  --accent-glow: rgba(155, 109, 255, 0.35);
-  --accent-bright: #b48aff;
+  --color-text:         #e2e2f0;
+  --color-text-dim:     #8888a8;
+  --color-text-muted:   #44445a;
 
-  --teal: #00d4aa;
-  --teal-dim: rgba(0, 212, 170, 0.15);
+  --color-accent:       #9b6dff;
+  --color-accent-bright:#b48aff;
+  --color-teal:         #00d4aa;
+  --color-error:        #ff5f7e;
 
-  --error-color: #ff5f7e;
+  --color-green:        #4ade80;
+  --color-orange:       #fb923c;
+  --color-red:          #f87171;
+  --color-purple:       #a78bfa;
+  --color-indigo:       #818cf8;
 
-  --radius: 10px;
-  --radius-sm: 6px;
-
-  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
-
-  /* Glass design tokens */
-  --glass-bg: rgba(12, 12, 22, 0.55);
-  --glass-border: rgba(255, 255, 255, 0.07);
-  --glass-blur: 24px;
-  /* glass-glow uses var(--accent-dim) so it auto-updates with themes */
-  --glass-glow: 0 0 0 1px var(--accent-dim), 0 8px 32px rgba(0, 0, 0, 0.4);
-
-  /* Derived accent tokens for borders/shadows — override these per theme */
-  --accent-subtle: rgba(155, 109, 255, 0.22);
-  --accent-faint:  rgba(155, 109, 255, 0.10);
-
-  /* Aurora hue-shift per theme — applied as filter on the aurora layers */
-  --aurora-filter: none;
-
-  /* Button glass tokens */
-  --btn-glass-bg:         rgba(10, 10, 15, 0.40);
-  --btn-glass-border:     rgba(255, 255, 255, 0.09);
-  --btn-glass-edge:       rgba(255, 255, 255, 0.13);
-  --btn-glass-blur:       16px;
-  --btn-tilt-perspective: 300px;
+  --font-mono:          'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  --radius:             10px;
+  --radius-sm:          6px;
 }
 
-/* ── Reset ─────────────────────────────────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+/* ── Base styles ────────────────────────────────────────────────────────── */
+/* Tailwind preflight handles the box-sizing reset. We add app-specific base. */
+@layer base {
+  :root {
+    /* Semantic aliases kept as CSS vars — referenced throughout the stylesheet */
+    --bg: #080810;
+    --surface: #0f0f1a;
+    --surface-2: #141424;
+    --surface-3: #1a1a2e;
+    --border: #1e1e32;
+    --border-2: #28283d;
+    --text: #e2e2f0;
+    --text-dim: #8888a8;
+    --text-muted: #44445a;
+    --accent: #9b6dff;
+    --accent-dim: rgba(155, 109, 255, 0.18);
+    --accent-glow: rgba(155, 109, 255, 0.35);
+    --accent-bright: #b48aff;
+    --teal: #00d4aa;
+    --teal-dim: rgba(0, 212, 170, 0.15);
+    --error-color: #ff5f7e;
+    --glass-bg: rgba(12, 12, 22, 0.55);
+    --glass-border: rgba(255, 255, 255, 0.07);
+    --glass-blur: 24px;
+    --glass-glow: 0 0 0 1px var(--accent-dim), 0 8px 32px rgba(0, 0, 0, 0.4);
+    --accent-subtle: rgba(155, 109, 255, 0.22);
+    --accent-faint:  rgba(155, 109, 255, 0.10);
+    --aurora-filter: none;
+    --btn-glass-bg:         rgba(10, 10, 15, 0.40);
+    --btn-glass-border:     rgba(255, 255, 255, 0.09);
+    --btn-glass-edge:       rgba(255, 255, 255, 0.13);
+    --btn-glass-blur:       16px;
+    --btn-tilt-perspective: 300px;
+    /* JS-driven reactive values — updated each RAF frame by AnomalySphere */
+    --aurora-bass:   0;
+    --aurora-mid:    0;
+    --aurora-treble: 0;
+    --ui-bass:    0;
+    --ui-treble:  0;
+  }
 
-html {
-  height: 100%;
-  scroll-behavior: smooth;
-  overscroll-behavior: none;
+  html {
+    height: 100%;
+    scroll-behavior: smooth;
+    overscroll-behavior: none;
+  }
+
+  body {
+    min-height: 100%;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
 }
 
-body {
-  min-height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-  overflow: hidden;
-  overscroll-behavior: none;
+/* ── Component utilities ────────────────────────────────────────────────── */
+/* Reusable Tailwind component classes. Use these with @apply in Tailwind HTML
+   or as standalone classes. Complex CSS-var patterns that can't be pure utilities
+   stay here; simple ones become @apply chains. */
+@layer components {
+  /* Glassmorphism panel — base glass surface used by drawers, modals, cards */
+  .glass {
+    @apply backdrop-blur-xl border border-white/[0.07];
+    background: var(--glass-bg);
+    box-shadow: var(--glass-glow);
+  }
+
+  /* Dark glass for player bars (player-top, player-bottom, header) */
+  .glass-dark {
+    backdrop-filter: blur(44px);
+    -webkit-backdrop-filter: blur(44px);
+    background: rgba(2, 2, 8, 0.97);
+    border-color: rgba(255, 255, 255, 0.06);
+  }
+
+  /* Accent glass panel — used for controls/settings drawers */
+  .glass-accent {
+    @apply backdrop-blur-[44px] border;
+    background: rgba(3, 3, 12, 0.97);
+    border-color: rgba(124, 77, 255, 0.18);
+    border-radius: 14px;
+    box-shadow: 0 0 0 1px rgba(124, 77, 255, 0.05), 0 28px 90px rgba(0, 0, 0, 0.80);
+  }
+
+  /* Teal glass panel — used for settings drawer */
+  .glass-teal {
+    @apply backdrop-blur-[44px] border;
+    background: rgba(3, 3, 12, 0.97);
+    border-color: rgba(0, 201, 160, 0.18);
+    border-radius: 14px;
+    box-shadow: 0 0 0 1px rgba(0, 201, 160, 0.05), 0 28px 90px rgba(0, 0, 0, 0.80);
+  }
+
+  /* Pill / icon button base */
+  .btn-base {
+    @apply inline-flex items-center justify-center
+           rounded-[10px] border border-white/[0.07]
+           bg-white/[0.025] text-[var(--text-dim)]
+           transition-colors duration-150
+           cursor-pointer select-none
+           hover:bg-accent/10 hover:border-accent/30 hover:text-[var(--accent-bright)];
+  }
+
+  /* Screen-reader only — kept here for @apply compatibility */
+  .sr-only {
+    @apply absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
 }
 
 /* Aurora gradient background - animated color blobs behind the glass UI.
    CSS variables --aurora-bass, --aurora-mid, --aurora-treble are updated
-   by SpectrumAnalyzer each frame so the aurora reacts to the live audio. */
-:root {
-  --aurora-bass:   0;
-  --aurora-mid:    0;
-  --aurora-treble: 0;
-  /* Fast-attack beat-pulse values — drive snappy UI reactivity */
-  --ui-bass:    0;
-  --ui-treble:  0;
-}
-
+   by AnomalySphere each frame so the aurora reacts to the live audio.
+   Initial values are set in @layer base :root block above. */
 body::before {
   content: '';
   position: fixed;
@@ -185,7 +257,7 @@ body::after {
 #app {
   position: relative;
   z-index: 1;
-  min-height: 100vh;
+  min-height: 100svh;
 }
 
 /* ── Full-page orb canvas ────────────────────────────────────────────────── */
@@ -196,7 +268,13 @@ body::after {
   inset: 0;
   z-index: 1;  /* above page bg, below aurora (z-2) and UI (z-50+) */
   pointer-events: none;
-  will-change: transform;  /* own compositing layer — prevents compositor disruption when aurora filter activates on preset selection */
+  /* isolation:isolate creates a stacking context WITHOUT promoting a GPU texture
+     layer. Using will-change:transform here caused Chrome's Skia compositor to
+     re-sample every backdrop-filter element above on each WebGL frame swap,
+     producing a one-frame stale-capture flash ("screen glitch") on Chrome macOS.
+     transform:translateZ(0) retains the GPU layer hint without that side-effect. */
+  isolation: isolate;
+  transform: translateZ(0);
 }
 
 /* Three.js canvas fills the container */
@@ -257,7 +335,7 @@ body::after {
 /* ── Main ───────────────────────────────────────────────────────────────── */
 .main {
   position: relative;
-  min-height: 100vh;
+  min-height: 100svh;
 }
 
 /* ── Drop zone — full-page overlay before a file is loaded ──────────────── */
@@ -1117,7 +1195,7 @@ body.is-paused .btn-play {
     width: auto;
     border-radius: var(--radius) var(--radius) 0 0;
     bottom: 175px;
-    max-height: calc(100vh - 280px);
+    max-height: calc(100svh - 280px);
   }
 
   /* Two-row transport layout so Controls and Effects buttons are never hidden.
@@ -1795,7 +1873,7 @@ body.is-paused .site-footer {
   border: 1px solid var(--accent-subtle);
   border-radius: var(--radius);
   box-shadow: 0 0 0 1px var(--accent-faint), 0 20px 60px rgba(0, 0, 0, 0.65);
-  max-height: calc(100vh - 310px);
+  max-height: calc(100dvh - 310px);
   overflow-y: auto;
 }
 
@@ -1812,7 +1890,7 @@ body.is-paused .site-footer {
   border: 1px solid rgba(0, 212, 170, 0.20);
   border-radius: var(--radius);
   box-shadow: 0 0 0 1px rgba(0, 212, 170, 0.08), 0 20px 60px rgba(0, 0, 0, 0.65);
-  max-height: calc(100vh - 310px);
+  max-height: calc(100dvh - 310px);
   overflow-y: auto;
 }
 
@@ -2314,8 +2392,8 @@ body.is-paused .site-footer {
 /* ── Fullscreen layout fill ─────────────────────────────────────────────── */
 :fullscreen #app,
 :-webkit-full-screen #app {
-  width: 100vw;
-  height: 100vh;
+  width: 100dvw;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -2344,7 +2422,7 @@ body.is-paused .site-footer {
   padding: 4px 0;
   margin: 0;
   overflow-y: auto;
-  max-height: calc(100vh - 180px);
+  max-height: calc(100dvh - 180px);
 }
 .playlist-item {
   display: flex;
@@ -2456,7 +2534,7 @@ body.is-paused .site-footer {
   color: var(--text, rgba(240, 240, 255, 0.92));
   padding: 0;
   max-width: 460px;
-  width: calc(100vw - 40px);
+  width: calc(100dvw - 40px);
   box-shadow: 0 0 0 1px rgba(155, 109, 255, 0.12), 0 20px 60px rgba(0, 0, 0, 0.75);
 }
 #help-modal::backdrop {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1063,6 +1063,11 @@ body.is-paused .btn-play {
   background: var(--border-2);
   outline: none;
   cursor: pointer;
+  /* touch-action: none — tells iOS/Android that this element owns the touch
+     entirely. Without this, horizontal drags on a range input inside a
+     scrollable container get intercepted by the OS scroll handler and the
+     slider value never changes. */
+  touch-action: none;
 }
 
 .slider::-webkit-slider-thumb {
@@ -1189,13 +1194,15 @@ body.is-paused .btn-play {
 
   /* Drawers: full-width at bottom of phones */
   .controls-drawer,
+  .sound-drawer,
   .settings-drawer {
     right: 0;
     left: 0;
     width: auto;
     border-radius: var(--radius) var(--radius) 0 0;
     bottom: 175px;
-    max-height: calc(100svh - 280px);
+    height: calc(100dvh - 260px);
+    max-height: calc(100dvh - 260px);
   }
 
   /* Two-row transport layout so Controls and Effects buttons are never hidden.
@@ -1784,6 +1791,9 @@ body.is-paused .site-footer {
   padding: 8px 12px;
   border-bottom: 1px solid var(--glass-border);
   margin-bottom: 4px;
+  flex-shrink: 0; /* never compressed by flex: pinned header */
+  position: relative;
+  z-index: 2;
 }
 
 .controls-drawer-title {
@@ -1853,51 +1863,206 @@ body.is-paused .site-footer {
   box-shadow: 0 0 0 2px var(--accent);
 }
 
-/* Hidden state — added by JS when drawer is open, removed when closed */
-.controls-drawer--hidden {
-  display: none !important;
+/* ── Panel animation system ────────────────────────────────────────────────
+   All drawers use pointer-events + opacity + transform instead of display:none
+   so CSS transitions can run. .panel--visible is toggled by JS.             */
+.controls-drawer,
+.sound-drawer,
+.settings-drawer {
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms ease-in, transform 150ms ease-in;
 }
 
-/* Controls drawer — fixed panel above the bottom bar, on the right.
-   max-height accounts for header (54px) + player-top (~54px) + bottom bar (~172px)
-   so expanding the Effects Chain section never pushes the drawer above the top panel. */
+/* Right-side panels slide in from the right */
+.controls-drawer,
+.sound-drawer {
+  transform: translateX(16px);
+}
+
+/* Left-side panel slides in from the left */
+.settings-drawer {
+  transform: translateX(-16px);
+}
+
+.controls-drawer.panel--visible,
+.sound-drawer.panel--visible,
+.settings-drawer.panel--visible {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateX(0);
+  transition: opacity 200ms ease-out, transform 200ms ease-out;
+}
+
+/* On mobile, drawers are full-width bottom sheets — slide up instead of sideways */
+@media (max-width: 600px) {
+  .controls-drawer,
+  .sound-drawer,
+  .settings-drawer {
+    transform: translateY(16px);
+  }
+  .controls-drawer.panel--visible,
+  .sound-drawer.panel--visible,
+  .settings-drawer.panel--visible {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .controls-drawer, .sound-drawer, .settings-drawer {
+    transition: none !important;
+  }
+}
+
+/* Controls/Playlist drawer — fixed panel above the bottom bar, on the right */
 .controls-drawer {
   position: fixed;
   right: 20px;
   bottom: 172px;
-  width: 300px;
+  width: 310px;
   z-index: 60;
-  background: rgba(8, 8, 18, 0.90);
+  background: rgba(8, 8, 18, 0.92);
   backdrop-filter: blur(32px);
   -webkit-backdrop-filter: blur(32px);
   border: 1px solid var(--accent-subtle);
   border-radius: var(--radius);
   box-shadow: 0 0 0 1px var(--accent-faint), 0 20px 60px rgba(0, 0, 0, 0.65);
+  /* Definite height (not just max-height) is required for flex distribution:
+     flex children with flex-grow can only consume space from a definite height.
+     max-height alone is not "definite" in the CSS spec — the scroll body stays 0. */
+  height: calc(100dvh - 310px);
   max-height: calc(100dvh - 310px);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-/* ── Visual Settings drawer — left side, same glass style ───────────────── */
+/* ── Sound drawer (unified Audio + Effects) ─────────────────────────────── */
+.sound-drawer {
+  position: fixed;
+  right: 20px;
+  bottom: 172px;
+  width: 310px;
+  z-index: 60;
+  background: rgba(8, 8, 18, 0.92);
+  backdrop-filter: blur(32px);
+  -webkit-backdrop-filter: blur(32px);
+  border: 1px solid var(--accent-subtle);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 1px var(--accent-faint), 0 20px 60px rgba(0, 0, 0, 0.65);
+  height: calc(100dvh - 310px);
+  max-height: calc(100dvh - 310px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sound-drawer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 10px 14px;
+  border-bottom: 1px solid var(--border);
+  /* position:sticky inside overflow:hidden is broken on iOS and causes
+     hit-test mismatches — the header taps pass through to the scroll body.
+     Use position:relative + z-index so it stacks correctly but doesn't try to stick. */
+  position: relative;
+  z-index: 2;
+  flex-shrink: 0;
+  background: rgba(8, 8, 18, 0.96);
+  /* backdrop-filter removed — the drawer already blurs; double-blurring the header
+     creates a compositing layer that can steal touches on iOS */
+}
+
+/* ── Shared tab nav (Sound panel + Help modal) ──────────────────────────── */
+.sound-tabs,
+.help-tabs {
+  display: flex;
+  gap: 2px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 7px;
+  padding: 3px;
+  flex: 1;
+}
+
+.sound-tab,
+.help-tab {
+  flex: 1;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.sound-tab:hover,
+.help-tab:hover {
+  color: var(--text);
+}
+
+.sound-tab--active,
+.help-tab--active {
+  background: var(--accent-dim);
+  color: var(--accent-bright);
+}
+
+.sound-tab-panel--hidden,
+.help-tab-panel--hidden {
+  display: none;
+}
+
+/* ── Section labels inside tabs ─────────────────────────────────────────── */
+.control-section-label {
+  padding: 10px 16px 4px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* ── Visual Settings drawer — left side ─────────────────────────────────── */
 .settings-drawer {
   position: fixed;
   left: 20px;
   bottom: 172px;
   width: 290px;
   z-index: 60;
-  background: rgba(8, 8, 18, 0.90);
+  background: rgba(8, 8, 18, 0.92);
   backdrop-filter: blur(32px);
   -webkit-backdrop-filter: blur(32px);
   border: 1px solid rgba(0, 212, 170, 0.20);
   border-radius: var(--radius);
   box-shadow: 0 0 0 1px rgba(0, 212, 170, 0.08), 0 20px 60px rgba(0, 0, 0, 0.65);
+  height: calc(100dvh - 310px);
   max-height: calc(100dvh - 310px);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.settings-drawer--hidden {
-  display: none !important;
+/* ── Inner scroll wrapper — the only element that actually scrolls ─────── */
+/* iOS Safari requires a dedicated scroll child inside position:fixed parents.
+   Using overflow:hidden on the drawer + overflow-y:scroll here fixes the
+   classic "can't scroll inside position:fixed" bug on iOS. */
+.drawer-scroll-body {
+  flex: 1 1 auto;
+  min-height: 0; /* lets flex child shrink below content intrinsic size */
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
 }
 
+/* Drawers already blur their entire surface — inner .controls panels don't
+   need their own backdrop-filter. Extra compositing layers on iOS cause
+   touch dispatch issues inside overflow:scroll containers. */
+.sound-drawer .controls,
 .settings-drawer .controls {
   background: transparent;
   backdrop-filter: none;
@@ -2346,20 +2511,14 @@ body.is-paused .site-footer {
 }
 
 /* ── Safe-area-aware drawer positioning on notched phones ───────────────── */
-/* The drawers sit 148px above the transport bar. On notched phones that bar
+/* The drawers sit above the transport bar. On notched phones that bar
    itself gets extra bottom padding, so the drawers need to shift up too. */
 @media (max-width: 600px) {
   .controls-drawer,
+  .sound-drawer,
   .settings-drawer {
     bottom: calc(175px + env(safe-area-inset-bottom));
   }
-}
-
-/* ── iOS momentum scroll for drawers ────────────────────────────────────── */
-/* Gives the panel scroll areas a native rubber-band feel on iOS Safari. */
-.controls-drawer,
-.settings-drawer {
-  -webkit-overflow-scrolling: touch;
 }
 
 /* ── Fullscreen button ──────────────────────────────────────────────────── */
@@ -2404,6 +2563,7 @@ body.is-paused .site-footer {
   .waveform { height: 80px; }
 
   .controls-drawer,
+  .sound-drawer,
   .settings-drawer {
     max-width: 380px;
   }
@@ -2421,8 +2581,7 @@ body.is-paused .site-footer {
   list-style: none;
   padding: 4px 0;
   margin: 0;
-  overflow-y: auto;
-  max-height: calc(100dvh - 180px);
+  /* overflow handled by .drawer-scroll-body parent — no nested scroll */
 }
 .playlist-item {
   display: flex;
@@ -2464,12 +2623,54 @@ body.is-paused .site-footer {
   outline: 2px solid var(--accent, #9b6dff);
   outline-offset: 2px;
 }
+/* ── Playlist search ─────────────────────────────────────────────────────── */
+.playlist-search-wrap {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0; /* pinned above scroll body */
+}
+.playlist-search {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.playlist-search::placeholder { color: var(--text-muted); }
+.playlist-search:focus { border-color: rgba(155, 109, 255, 0.40); }
+
+/* ── Playlist item info (name + meta) ───────────────────────────────────── */
+.playlist-item-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.playlist-item-meta {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Playlist footer ─────────────────────────────────────────────────────── */
 .playlist-footer {
-  padding: 10px 16px 14px;
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px 14px;
   border-top: 1px solid rgba(155, 109, 255, 0.08);
+  flex-shrink: 0; /* pinned footer below scroll body */
 }
 .btn-playlist-add {
-  width: 100%;
+  flex: 1;
   padding: 7px 12px;
   background: rgba(155, 109, 255, 0.10);
   border: 1px solid rgba(155, 109, 255, 0.25);
@@ -2482,6 +2683,25 @@ body.is-paused .site-footer {
 .btn-playlist-add:hover { background: rgba(155, 109, 255, 0.18); }
 .btn-playlist-add:focus-visible {
   outline: 2px solid var(--accent, #9b6dff);
+  outline-offset: 2px;
+}
+.btn-playlist-clear {
+  padding: 7px 12px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.btn-playlist-clear:hover {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: var(--red, #f87171);
+}
+.btn-playlist-clear:focus-visible {
+  outline: 2px solid var(--red, #f87171);
   outline-offset: 2px;
 }
 
@@ -2524,7 +2744,7 @@ body.is-paused .site-footer {
   min-width: 36px;
 }
 
-/* ── Keyboard shortcut help modal ───────────────────────────────────────── */
+/* ── Help modal ─────────────────────────────────────────────────────────── */
 #help-modal {
   border: 1px solid var(--accent-subtle, rgba(155, 109, 255, 0.3));
   border-radius: var(--radius, 12px);
@@ -2533,54 +2753,64 @@ body.is-paused .site-footer {
   -webkit-backdrop-filter: blur(32px);
   color: var(--text, rgba(240, 240, 255, 0.92));
   padding: 0;
-  max-width: 460px;
+  max-width: 600px;
   width: calc(100dvw - 40px);
+  max-height: calc(100dvh - 80px);
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(155, 109, 255, 0.12), 0 20px 60px rgba(0, 0, 0, 0.75);
+  margin: auto;
 }
 #help-modal::backdrop {
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(4px);
 }
 .help-modal-inner {
-  padding: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100dvh - 80px);
 }
 .help-modal-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px 12px;
+  gap: 8px;
+  padding: 12px 14px 12px 16px;
   border-bottom: 1px solid rgba(155, 109, 255, 0.15);
+  flex-shrink: 0;
 }
-.help-modal-title {
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  color: var(--accent, #9b6dff);
+
+/* ── Shortcuts tab content ──────────────────────────────────────────────── */
+.help-tab-panel {
+  overflow-y: auto;
+  max-height: calc(100dvh - 160px);
+  padding: 16px 20px 20px;
 }
-.help-modal-close {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-  font-size: 1.2rem;
-  line-height: 1;
-  opacity: 0.65;
-  padding: 2px 6px;
-  border-radius: 4px;
-  transition: opacity 0.15s;
+.shortcut-sections {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
 }
-.help-modal-close:hover { opacity: 1; }
-.help-modal-close:focus-visible {
-  outline: 2px solid var(--accent, #9b6dff);
-  outline-offset: 2px;
+@media (max-width: 480px) {
+  .shortcut-sections { grid-template-columns: 1fr; }
+}
+.shortcut-section-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+  grid-column: 1 / -1;
+}
+.shortcut-section {
+  display: contents;
 }
 .shortcut-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px 12px;
-  padding: 14px 20px 20px;
-  margin: 0;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  margin: 0 0 2px;
 }
 .shortcut-row {
   display: contents;
@@ -2588,25 +2818,129 @@ body.is-paused .site-footer {
 .shortcut-row dt {
   display: flex;
   align-items: center;
-  padding: 5px 0;
+  padding: 4px 0;
 }
 .shortcut-row dd {
   display: flex;
   align-items: center;
-  padding: 5px 0;
+  padding: 4px 0;
   margin: 0;
-  font-size: 0.82rem;
-  opacity: 0.8;
+  font-size: 0.8rem;
+  color: var(--text-dim);
 }
 .shortcut-row dt kbd {
   font-family: ui-monospace, SFMono-Regular, monospace;
   border: 1px solid rgba(155, 109, 255, 0.35);
   border-radius: 5px;
   padding: 3px 8px;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   background: rgba(155, 109, 255, 0.10);
   color: var(--accent, #9b6dff);
   white-space: nowrap;
+}
+
+/* ── Feature Guide tab ──────────────────────────────────────────────────── */
+.guide-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 24px;
+}
+@media (max-width: 520px) { .guide-grid { grid-template-columns: 1fr; } }
+.guide-section-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-bright);
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 10px;
+}
+.guide-list {
+  margin: 0 0 16px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+.guide-row {
+  display: contents;
+}
+.guide-row dt {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  padding: 5px 0 1px;
+}
+.guide-row dd {
+  font-size: 0.77rem;
+  color: var(--text-dim);
+  margin: 0 0 4px;
+  line-height: 1.4;
+}
+
+/* ── About tab ──────────────────────────────────────────────────────────── */
+.about-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: 12px 0 4px;
+}
+.about-logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  color: var(--accent-bright);
+}
+.about-version {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  margin-top: -6px;
+}
+.about-desc {
+  font-size: 0.83rem;
+  color: var(--text-dim);
+  line-height: 1.5;
+  max-width: 340px;
+  margin: 4px 0;
+}
+.about-github {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--accent-bright);
+  opacity: 0.7;
+  text-decoration: none;
+  margin-top: 8px;
+  transition: opacity 0.15s;
+}
+.about-github:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+.about-stack-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.about-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+}
+.about-stack span {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  padding: 3px 10px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 100px;
+  color: var(--accent-bright);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -2983,11 +3317,12 @@ body.is-paused .site-footer {
   -webkit-backdrop-filter: none;
 }
 
-.btn-controls-show:hover {
-  background: rgba(124, 77, 255, 0.09);
-  border-color: rgba(124, 77, 255, 0.32);
+.btn-controls-show:hover,
+.btn-controls-show--active {
+  background: rgba(124, 77, 255, 0.12);
+  border-color: rgba(124, 77, 255, 0.40);
   color: var(--accent-bright);
-  box-shadow: 0 0 12px rgba(124, 77, 255, 0.10);
+  box-shadow: 0 0 12px rgba(124, 77, 255, 0.12);
 }
 
 .btn-settings-show {
@@ -3009,7 +3344,8 @@ body.is-paused .site-footer {
 }
 
 /* ── Control drawers — refined dark panels ───────────────────────────────── */
-.controls-drawer {
+.controls-drawer,
+.sound-drawer {
   background: rgba(3, 3, 12, 0.97);
   backdrop-filter: blur(44px);
   -webkit-backdrop-filter: blur(44px);
@@ -3036,9 +3372,15 @@ body.is-paused .site-footer {
 
 @media (max-width: 600px) {
   .controls-drawer,
+  .sound-drawer,
   .settings-drawer {
     bottom: calc(190px + env(safe-area-inset-bottom));
     border-radius: 14px 14px 0 0;
+    right: 0;
+    left: 0;
+    width: auto;
+    height: calc(100dvh - 275px - env(safe-area-inset-bottom));
+    max-height: calc(100dvh - 275px - env(safe-area-inset-bottom));
   }
 }
 
@@ -3333,5 +3675,38 @@ body::after {
 .page-loader-icon {
   color: #7c4dff;
   filter: drop-shadow(0 0 12px rgba(124, 77, 255, 0.55));
+}
+
+/* ── Mobile drawer backdrop ─────────────────────────────────────────────── */
+/* Appears behind open drawers on phones so users can tap-to-close.
+   Hidden on desktop (min-width: 601px) via !important so it never shows. */
+.drawer-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.50);
+  z-index: 45;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.drawer-backdrop.backdrop--visible {
+  display: block;
+}
+@media (min-width: 601px) {
+  .drawer-backdrop { display: none !important; }
+}
+
+/* ── Aurora idle animation (mobile) ────────────────────────────────────── */
+/* On mobile, JS stops updating --aurora-* CSS vars to avoid style-recalc
+   on every backdrop-filter layer. The aurora stays alive via this keyframe. */
+@keyframes aurora-idle {
+  from { opacity: 0.30; }
+  to   { opacity: 0.60; }
+}
+@media (max-width: 600px) {
+  body::before,
+  body::after {
+    animation: aurora-idle 8s ease-in-out infinite alternate;
+  }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,26 @@ export interface AudioParams {
   pitchSemitones: number    // -12 to +12 semitones (0 = no shift)
 }
 
+export interface VisualParams {
+  reactivity?:     number   // beat response  [0.00 – 1.00]
+  glow?:           number   // bloom amount   [0.00 – 1.50]
+  orbSize?:        number   // sphere scale   [0.40 – 1.80]
+  rotationSpeed?:  number   // spin rate      [0.00 – 2.00]
+  stars?:          number   // star field     [0.00 – 1.00]
+  particleCount?:  number   // particle cloud [0 – 2000]
+  wireframe?:      boolean
+  bassPulse?:      boolean
+  lightning?:      boolean
+  crack?:          boolean
+  crystal?:        boolean
+  glitch?:         boolean
+}
+
 export interface PresetDefinition {
   id: string
   name: string
   theme?: string
   params: AudioParams
+  visual?: VisualParams
 }
 

--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -21,8 +21,7 @@ import {
   Color,
   Vector2,
   Vector3,
-  IcosahedronGeometry,
-  ShaderMaterial,
+  RawShaderMaterial,  // OGL-style: no Three.js built-in injection; we declare all uniforms/attributes
   BufferGeometry,
   BufferAttribute,
   Texture,
@@ -92,7 +91,19 @@ float snoise(vec3 v){
 // Four displacement layers + idle breath. uSpeed warps time so slow playback
 // makes the surface deform more languidly with bigger bulges.
 const VERTEX_SHADER = /* glsl */`
+precision highp float;
+precision highp int;
+
 ${GLSL_NOISE}
+
+// Three.js built-ins — must be declared manually with RawShaderMaterial
+attribute vec3 position;
+attribute vec3 normal;
+
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+uniform mat4 modelMatrix;
+uniform mat3 normalMatrix;
 
 uniform float uTime;
 uniform float uBass;
@@ -139,7 +150,13 @@ void main() {
 // Color uniforms rotate each frame so the palette cycles with the beat.
 // uReverb adds iridescent wash — high reverb makes the orb look wet and blurry.
 const FRAGMENT_SHADER = /* glsl */`
+precision highp float;
+precision highp int;
+
 ${GLSL_NOISE}
+
+// cameraPosition must be declared manually with RawShaderMaterial
+uniform vec3 cameraPosition;
 
 uniform float uBass;
 uniform float uMid;
@@ -230,6 +247,13 @@ void main() {
 // Each star has a random twinkle speed and phase so they glisten independently.
 // Treble energy makes peaks sharper — hi-hats cause the whole sky to sparkle.
 const STAR_VERT = /* glsl */`
+precision highp float;
+precision highp int;
+
+attribute vec3 position;
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
 uniform float uTime;
 uniform float uTreble;
 attribute float aPhase;
@@ -253,6 +277,9 @@ void main() {
 `
 
 const STAR_FRAG = /* glsl */`
+precision highp float;
+precision highp int;
+
 uniform float uBrightness;
 varying float vAlpha;
 varying float vSpark;
@@ -281,6 +308,13 @@ void main() {
 // Each particle slowly orbits at a random phase; bass pushes them outward and
 // treble makes them brighter and larger.
 const PARTICLE_VERT = /* glsl */`
+precision highp float;
+precision highp int;
+
+attribute vec3 position;
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
 uniform float uBass;
 uniform float uTreble;
 uniform float uTime;
@@ -321,6 +355,9 @@ void main() {
 // Sharp dot: bright solid core with a tight falloff so particles read as
 // crisp sparks rather than blurry blobs.
 const PARTICLE_FRAG = /* glsl */`
+precision highp float;
+precision highp int;
+
 uniform vec3 uParticleColor;
 varying float vAlpha;
 
@@ -475,6 +512,83 @@ const THEME_PALETTES: Record<string, Array<[number, number, number]>> = {
   ember: [[0.03, 0.95, 0.55], [0.09, 0.92, 0.57], [0.00, 0.88, 0.45], [0.14, 0.85, 0.55]],
   frost: [[0.56, 0.72, 0.65], [0.51, 0.65, 0.70], [0.61, 0.60, 0.68], [0.58, 0.48, 0.78]],
   mono:  [[0.00, 0.04, 0.55], [0.00, 0.04, 0.65], [0.00, 0.04, 0.70], [0.00, 0.04, 0.45]],
+}
+
+// ── Manual icosahedron (replaces Three.js IcosahedronGeometry) ───────────────
+// Builds a geodesic sphere by starting from the 12-vertex icosahedron and
+// applying midpoint subdivision `detail` times. Vertices are projected onto
+// the unit sphere after each split so the surface stays perfectly round.
+// Returns a raw BufferGeometry with `position` and `normal` attributes.
+// On the unit sphere, position === normal, so both attributes share the same data.
+function buildIcosahedron(detail: number): BufferGeometry {
+  const PHI = (1 + Math.sqrt(5)) / 2
+  const rawVerts = [
+    -1,  PHI, 0,   1,  PHI, 0,  -1, -PHI, 0,   1, -PHI, 0,
+     0, -1,  PHI,  0,  1,  PHI,  0, -1, -PHI,   0,  1, -PHI,
+     PHI, 0, -1,   PHI, 0,  1,  -PHI, 0, -1,  -PHI, 0,  1,
+  ]
+  // Project all vertices onto the unit sphere
+  const verts: number[] = []
+  for (let i = 0; i < rawVerts.length; i += 3) {
+    const x = rawVerts[i], y = rawVerts[i + 1], z = rawVerts[i + 2]
+    const len = Math.sqrt(x * x + y * y + z * z)
+    verts.push(x / len, y / len, z / len)
+  }
+
+  let faces = [
+    0,11,5,  0,5,1,  0,1,7,  0,7,10,  0,10,11,
+    1,5,9,  5,11,4,  11,10,2,  10,7,6,  7,1,8,
+    3,9,4,  3,4,2,  3,2,6,  3,6,8,  3,8,9,
+    4,9,5,  2,4,11,  6,2,10,  8,6,7,  9,8,1,
+  ]
+
+  // Compute midpoint between two vertex indices, project onto sphere, cache result
+  const midCache = new Map<number, number>()
+  const getMid = (a: number, b: number): number => {
+    // Pack two 16-bit indices into one 32-bit key (works up to 65535 verts)
+    const key = (Math.min(a, b) << 16) | Math.max(a, b)
+    let idx = midCache.get(key)
+    if (idx !== undefined) return idx
+    const ax = verts[a * 3], ay = verts[a * 3 + 1], az = verts[a * 3 + 2]
+    const bx = verts[b * 3], by = verts[b * 3 + 1], bz = verts[b * 3 + 2]
+    const mx = ax + bx, my = ay + by, mz = az + bz
+    const len = Math.sqrt(mx * mx + my * my + mz * mz)
+    idx = verts.length / 3
+    verts.push(mx / len, my / len, mz / len)
+    midCache.set(key, idx)
+    return idx
+  }
+
+  for (let d = 0; d < detail; d++) {
+    const next: number[] = []
+    for (let i = 0; i < faces.length; i += 3) {
+      const a = faces[i], b = faces[i + 1], c = faces[i + 2]
+      const ab = getMid(a, b), bc = getMid(b, c), ca = getMid(c, a)
+      next.push(a, ab, ca,  b, bc, ab,  c, ca, bc,  ab, bc, ca)
+    }
+    faces = next
+    midCache.clear()
+  }
+
+  // Flatten into typed arrays — on the unit sphere, position === normal
+  const triCount = faces.length / 3
+  const positions = new Float32Array(triCount * 9)
+  const normals   = new Float32Array(triCount * 9)
+  for (let i = 0; i < faces.length; i += 3) {
+    const base = (i / 3) * 9
+    for (let j = 0; j < 3; j++) {
+      const vi = faces[i + j] * 3
+      const off = base + j * 3
+      positions[off]     = normals[off]     = verts[vi]
+      positions[off + 1] = normals[off + 1] = verts[vi + 1]
+      positions[off + 2] = normals[off + 2] = verts[vi + 2]
+    }
+  }
+
+  const geo = new BufferGeometry()
+  geo.setAttribute('position', new BufferAttribute(positions, 3))
+  geo.setAttribute('normal',   new BufferAttribute(normals,   3))
+  return geo
 }
 
 export class AnomalySphere {
@@ -636,13 +750,16 @@ export class AnomalySphere {
     // renderer area seamless — the orb appears to float over the page.
     // On mobile (DPR ≥ 3) cap at 2 to reduce WebGL framebuffer memory pressure.
     // Capping 3→2 cuts FBO size by ~44% — critical for avoiding iOS OOM page reloads.
-    // Use 'default' powerPreference so the GPU driver doesn't aggressively pre-allocate
-    // memory (which 'high-performance' can trigger on mobile).
     this._isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
     // Fewer particles on mobile to reduce JS heap pressure alongside the large
     // decoded AudioBuffer that can exceed 100 MB for long tracks.
     if (this._isMobile) this.particleCount = 150
-    this.renderer = new WebGLRenderer({ antialias: true, alpha: false, powerPreference: this._isMobile ? 'default' : 'high-performance' })
+    this.renderer = new WebGLRenderer({
+      antialias: !this._isMobile,  // MSAA doubles GPU framebuffer size — skip on mobile
+      alpha: false,
+      stencil: false,              // not used by this app; frees the depth+stencil buffer
+      powerPreference: this._isMobile ? 'low-power' : 'high-performance',
+    })
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this._isMobile ? 2 : 3))
     this.renderer.setClearColor(new Color('#080810'), 1)
     // ACESFilmic gracefully compresses HDR bloom values instead of clipping to white
@@ -678,9 +795,10 @@ export class AnomalySphere {
     this.camera.position.z = 4.2
 
     // ── Sphere geometry + material ───────────────────────────────────────────
-    // Detail level 6 → ~10k vertices for smooth high-frequency displacement.
-    // On mobile use level 4 (~2.5k vertices, 4× reduction) to cut GPU memory.
-    const geo = new IcosahedronGeometry(1, this._isMobile ? 4 : 6)
+    // buildIcosahedron() replaces Three.js IcosahedronGeometry — same geodesic
+    // subdivision, but implemented here so that class is not included in the bundle.
+    // Detail 6 → ~10k vertices; detail 4 → ~2.5k (~75% reduction) on mobile.
+    const geo = buildIcosahedron(this._isMobile ? 4 : 6)
 
     this.uniforms = {
       uTime:    { value: 0 },
@@ -698,7 +816,10 @@ export class AnomalySphere {
       uColorD:  { value: new Color('#ffaa44') },
     }
 
-    const mat = new ShaderMaterial({
+    // RawShaderMaterial (OGL-style): no Three.js built-in injection — all
+    // uniforms/attributes must be declared in the GLSL. Gives us full control
+    // over the shader environment and skips Three.js's uniform-injection overhead.
+    const mat = new RawShaderMaterial({
       uniforms:       this.uniforms,
       vertexShader:   VERTEX_SHADER,
       fragmentShader: FRAGMENT_SHADER,
@@ -719,8 +840,11 @@ export class AnomalySphere {
     this.composer = new EffectComposer(this.renderer)
     this.composer.addPass(new RenderPass(this.scene, this.camera))
 
+    // Halve bloom resolution on mobile — UnrealBloomPass creates 3-4 internal render
+    // targets; halving cuts their GPU memory footprint by ~75%.
+    const bloomRes = this._isMobile ? 150 : 300
     this.bloom = new UnrealBloomPass(
-      new Vector2(300, 300),
+      new Vector2(bloomRes, bloomRes),
       0.45,  // base strength — dimmer; reverb raises this at runtime
       0.38,
       0.22,
@@ -767,7 +891,7 @@ export class AnomalySphere {
       uParticleColor: { value: new Color('#b08aff') },
     }
 
-    const mat = new ShaderMaterial({
+    const mat = new RawShaderMaterial({
       uniforms:       this.particleUniforms,
       vertexShader:   PARTICLE_VERT,
       fragmentShader: PARTICLE_FRAG,
@@ -849,7 +973,7 @@ export class AnomalySphere {
       uBrightness: { value: 0.9 },
     }
 
-    const mat = new ShaderMaterial({
+    const mat = new RawShaderMaterial({
       uniforms:       this.starUniforms,
       vertexShader:   STAR_VERT,
       fragmentShader: STAR_FRAG,
@@ -1296,7 +1420,7 @@ export class AnomalySphere {
   setCrystal(v: boolean): void      { this.crystalEnabled = v }
 
   setWireframe(v: boolean): void {
-    ;(this.mesh.material as ShaderMaterial).wireframe = v
+    ;(this.mesh.material as RawShaderMaterial).wireframe = v
   }
 
   // Change the color theme. 'prism' = fully audio-reactive hue cycling.

--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -162,13 +162,14 @@ uniform float uBass;
 uniform float uMid;
 uniform float uTreble;
 uniform float uTime;
-uniform float uReverb;  // 0-1 — higher = more iridescent / glowy wash
-uniform float uCrack;   // 0-1 — fracture vein intensity, peaks on hard bass
-uniform float uCrystal; // 0-1 — crystallization, lerps toward 1 when paused
-uniform vec3  uColorA;  // hue 0   — cycles each frame
-uniform vec3  uColorB;  // hue +0.28 offset
-uniform vec3  uColorC;  // hue +0.55 offset
-uniform vec3  uColorD;  // hue +0.14 offset (bass warmth)
+uniform float uReverb;    // 0-1 — higher = more iridescent / glowy wash
+uniform float uCrack;     // 0-1 — fracture vein intensity, peaks on hard bass
+uniform float uCrystal;   // 0-1 — crystallization, lerps toward 1 when paused
+uniform float uWireframe; // 1.0 = wireframe mode — flat bright lines, no surface shading
+uniform vec3  uColorA;    // hue 0   — cycles each frame
+uniform vec3  uColorB;    // hue +0.28 offset
+uniform vec3  uColorC;    // hue +0.55 offset
+uniform vec3  uColorD;    // hue +0.14 offset (bass warmth)
 
 varying vec3  vNormal;
 varying vec3  vWorldPos;
@@ -201,7 +202,11 @@ void main() {
   // Equatorial mid-band mixes in proportionally to mid energy
   color = mix(color, colorEq, midBand * (0.35 + uMid * 0.65));
 
-  float dispBright = 0.12 + clamp(vDisp * 1.9, 0.0, 1.0) * 0.55;
+  // In wireframe mode blend toward a flat high brightness so all edges glow
+  // uniformly — the surface shading model (low base at 0.12) makes undisplaced
+  // lines near-invisible and creates a patchy, uneven look on the mesh.
+  float dispBrightSolid = 0.12 + clamp(vDisp * 1.9, 0.0, 1.0) * 0.55;
+  float dispBright = mix(dispBrightSolid, 0.68 + clamp(vDisp * 0.5, 0.0, 1.0) * 0.22, uWireframe);
 
   // Subtle iridescent shimmer — kept light so it doesn't hide the palette colors
   float iridHue  = fract(nDotV * 0.40 + vDisp * 0.30 + uTime * 0.035 + uBass * 0.25);
@@ -237,8 +242,11 @@ void main() {
     color += fresnel * iceColor * uCrystal * 0.55;
   }
 
-  // Reverb also slightly increases alpha — more verb = more ethereal opacity
-  float alpha = 0.40 + fresnel * 0.48 + uBass * 0.07 + uReverb * 0.06;
+  // Wireframe: lines should be nearly opaque so edges are crisp and neon-bright.
+  // Solid: keep the translucent depth with fresnel/audio reactivity.
+  float alphaSolid = 0.40 + fresnel * 0.48 + uBass * 0.07 + uReverb * 0.06;
+  float alphaWire  = 0.82 + fresnel * 0.14 + uBass * 0.04;
+  float alpha = mix(alphaSolid, alphaWire, uWireframe);
   gl_FragColor = vec4(color, clamp(alpha, 0.0, 1.0));
 }
 `
@@ -711,9 +719,10 @@ export class AnomalySphere {
     uReverb:  IUniform<number>
     uSpeed:   IUniform<number>
     uSubBass: IUniform<number>
-    uCrack:   IUniform<number>
-    uCrystal: IUniform<number>
-    uColorA:  IUniform<Color>
+    uCrack:      IUniform<number>
+    uCrystal:    IUniform<number>
+    uWireframe:  IUniform<number>
+    uColorA:     IUniform<Color>
     uColorB:  IUniform<Color>
     uColorC:  IUniform<Color>
     uColorD:  IUniform<Color>
@@ -734,6 +743,7 @@ export class AnomalySphere {
   private playing  = false
   private _reducedMotion: boolean
   private _motionMQ: MediaQueryList
+  private _onVisibilityChange: () => void
 
   // Called each frame with smoothed bass/mid/treble for the aurora, plus
   // fast-attack uiBass/uiTreble for snappy site-wide UI reactivity.
@@ -808,9 +818,10 @@ export class AnomalySphere {
       uReverb:  { value: this.reverb },
       uSpeed:   { value: this.speed },
       uSubBass: { value: 0 },
-      uCrack:   { value: 0 },
-      uCrystal: { value: 0 },
-      uColorA:  { value: new Color('#9b6dff') },
+      uCrack:      { value: 0 },
+      uCrystal:    { value: 0 },
+      uWireframe:  { value: 1.0 },
+      uColorA:     { value: new Color('#9b6dff') },
       uColorB:  { value: new Color('#00d4aa') },
       uColorC:  { value: new Color('#ff6eb4') },
       uColorD:  { value: new Color('#ffaa44') },
@@ -876,6 +887,16 @@ export class AnomalySphere {
     // orientationchange fires before the browser has applied the new viewport
     // dimensions, so defer resize by 150 ms to let the layout settle first.
     window.addEventListener('orientationchange', () => { setTimeout(() => this.resize(), 150) })
+
+    // Restart the RAF loop when the tab becomes visible again after being
+    // hidden (the loop cancels itself on visibilityState === 'hidden').
+    this._onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && this.rafId === null) {
+        this.loop()
+      }
+    }
+    document.addEventListener('visibilitychange', this._onVisibilityChange)
+
     this.loop()
     requestAnimationFrame(() => this.resize())
   }
@@ -929,12 +950,19 @@ export class AnomalySphere {
         : 2.5 + Math.random() * 7.5     // wide field:  2.5–10.0
     }
 
-    const geo = this.particles.geometry
-    geo.setAttribute('position', new BufferAttribute(positions, 3))
-    geo.setAttribute('aSize',    new BufferAttribute(sizes, 1))
-    geo.setAttribute('aPhase',   new BufferAttribute(phases, 1))
-    geo.setAttribute('aRadius',  new BufferAttribute(radii, 1))
-    geo.computeBoundingSphere()
+    // Create a fresh geometry so old GPU buffers are explicitly freed.
+    // Replacing BufferAttributes on a live geometry leaves the old GPU buffers
+    // allocated until GC — on iOS that may never happen, causing VRAM leaks
+    // each time the user adjusts the particle count slider.
+    const oldGeo = this.particles.geometry
+    const newGeo = new BufferGeometry()
+    newGeo.setAttribute('position', new BufferAttribute(positions, 3))
+    newGeo.setAttribute('aSize',    new BufferAttribute(sizes, 1))
+    newGeo.setAttribute('aPhase',   new BufferAttribute(phases, 1))
+    newGeo.setAttribute('aRadius',  new BufferAttribute(radii, 1))
+    newGeo.computeBoundingSphere()
+    this.particles.geometry = newGeo
+    oldGeo.dispose()
   }
 
   // Builds a 1 400-point starfield spread across a large sphere.
@@ -1012,10 +1040,15 @@ export class AnomalySphere {
   private loop(): void {
     this.rafId = requestAnimationFrame(() => this.loop())
 
-    // Skip GPU work while the tab is hidden on mobile. This prevents shader
-    // uniform mutations from accumulating and reduces memory pressure from
-    // background OS processes fighting for GPU resources on iOS.
-    if (this._isMobile && document.visibilityState === 'hidden') return
+    // Fully pause the RAF loop when the tab is hidden — cancel the pending
+    // frame so the loop stops firing entirely (not just skips rendering).
+    // The visibilitychange listener in the constructor restarts it on return.
+    // This prevents unbounded GPU/JS work while backgrounded on iOS and desktop.
+    if (document.visibilityState === 'hidden') {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+      return
+    }
 
     const elapsed = this.clock.getElapsedTime()
 
@@ -1421,6 +1454,7 @@ export class AnomalySphere {
 
   setWireframe(v: boolean): void {
     ;(this.mesh.material as RawShaderMaterial).wireframe = v
+    this.uniforms.uWireframe.value = v ? 1.0 : 0.0
   }
 
   // Change the color theme. 'prism' = fully audio-reactive hue cycling.
@@ -1491,12 +1525,37 @@ export class AnomalySphere {
 
   destroy(): void {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId)
+    this.rafId = null
+    document.removeEventListener('visibilitychange', this._onVisibilityChange)
+
+    // Lightning arcs
     for (const arc of this.lightningArcs) {
       this.scene.remove(arc.mesh)
       arc.mesh.geometry.dispose()
       ;(arc.mesh.material as LineBasicMaterial).dispose()
     }
     this.lightningArcs = []
+
+    // Main orb mesh
+    this.mesh.geometry.dispose()
+    ;(this.mesh.material as RawShaderMaterial).dispose()
+
+    // Particle cloud
+    this.particles.geometry.dispose()
+    ;(this.particles.material as RawShaderMaterial).dispose()
+
+    // Star field
+    this.stars.geometry.dispose()
+    ;(this.stars.material as RawShaderMaterial).dispose()
+
+    // Post-processing render targets
+    this.composer.dispose()
+
+    // Release the WebGL context immediately — tells iOS GPU driver to free VRAM
+    // now rather than waiting for GC (which may never run under memory pressure).
+    this.renderer.forceContextLoss()
     this.renderer.dispose()
+
+    this.scene.clear()
   }
 }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -33,6 +33,9 @@ export class App {
   private effects: EffectsController
   private exporter: ExportController
   private _mobile!: MobileController
+
+  private _isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+  private _auroraFrameN = 0
   // Core DOM refs
   private dropzone = document.getElementById('dropzone')!
   private fileInput = document.getElementById('fileInput') as HTMLInputElement
@@ -744,12 +747,17 @@ export class App {
           this.engine.analyserNode,
         )
         this.sphere.onEnergyUpdate = (bass, mid, treble, uiBass, uiTreble) => {
-          const root = document.documentElement.style
-          root.setProperty('--aurora-bass',   String(bass.toFixed(3)))
-          root.setProperty('--aurora-mid',    String(mid.toFixed(3)))
-          root.setProperty('--aurora-treble', String(treble.toFixed(3)))
-          root.setProperty('--ui-bass',       String(uiBass.toFixed(3)))
-          root.setProperty('--ui-treble',     String(uiTreble.toFixed(3)))
+          // On mobile, aurora vars trigger full style-recalc + compositor repaint on every
+          // backdrop-filter layer (6+). Throttle to every 3rd frame to cut repaint pressure
+          // from 60/s → 20/s — the primary fix for iOS OOM crashes during long playback.
+          if (!this._isMobile || ++this._auroraFrameN % 3 === 0) {
+            const root = document.documentElement.style
+            root.setProperty('--aurora-bass',   String(bass.toFixed(3)))
+            root.setProperty('--aurora-mid',    String(mid.toFixed(3)))
+            root.setProperty('--aurora-treble', String(treble.toFixed(3)))
+            root.setProperty('--ui-bass',       String(uiBass.toFixed(3)))
+            root.setProperty('--ui-treble',     String(uiTreble.toFixed(3)))
+          }
           this.starOverlay.setTreble(treble)
         }
         // Sync slider/toggle defaults to sphere immediately after construction so the

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1,3 +1,4 @@
+import { DEFAULTS } from '../config/defaults'
 import { AudioEngine } from '../audio/AudioEngine'
 import { detectBpm } from '../audio/BpmDetector'
 import { detectKey, NOTE_NAMES } from '../audio/KeyDetector'
@@ -35,7 +36,6 @@ export class App {
   private _mobile!: MobileController
 
   private _isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-  private _auroraFrameN = 0
   // Core DOM refs
   private dropzone = document.getElementById('dropzone')!
   private fileInput = document.getElementById('fileInput') as HTMLInputElement
@@ -66,16 +66,13 @@ export class App {
   private volumeSlider = document.getElementById('volumeSlider') as HTMLInputElement
   private volumeValue = document.getElementById('volumeValue')!
 
-  // Controls drawer refs
-  private controlsDrawer = document.getElementById('controlsDrawer')!
-  private controlsFloatBtn = document.getElementById('controlsFloatBtn')!
-  private controlsCloseBtn = document.getElementById('controlsCloseBtn')!
-  private controlsShowBtn = document.getElementById('controlsShowBtn')!
+  // Sound drawer refs (merged Audio + Effects)
+  private soundDrawer   = document.getElementById('soundDrawer')!
+  private soundShowBtn  = document.getElementById('soundShowBtn')!
+  private soundCloseBtn = document.getElementById('soundCloseBtn')!
 
-  // Effects drawer refs
-  private effectsDrawer   = document.getElementById('effectsDrawer')!
-  private effectsCloseBtn = document.getElementById('effectsCloseBtn')!
-  private effectsShowBtn  = document.getElementById('effectsShowBtn')!
+  // Mobile backdrop — shown behind open drawers on phones; tap to close
+  private _drawerBackdrop = document.getElementById('drawerBackdrop')!
 
   // Settings drawer refs
   private settingsDrawer   = document.getElementById('settingsDrawer')!
@@ -91,6 +88,7 @@ export class App {
   private playlist: File[]        = []
   private currentTrackIndex       = -1
   private _dragIndex              = -1
+  private _trackMeta              = new Map<number, { duration: number; key: string; bpm: number }>()
   private playlistDrawer          = document.getElementById('playlistDrawer')!
   private playlistCloseBtn        = document.getElementById('playlistCloseBtn')!
   private playlistShowBtn         = document.getElementById('playlistShowBtn')!
@@ -131,11 +129,13 @@ export class App {
     this.wireUI()
     this.wireKeyboard()
     this.wireCrossController()
-    this.wireControlsPanel()
-    this.wireEffectsPanel()
+    this.wireSoundPanel()
     this.wireSettingsPanel()
     this.wireHelpModal()
     this.wirePlaylistPanel()
+    this._drawerBackdrop.addEventListener('click', () => this.closeAllPanels())
+    this.wireSliderTouch()
+    this.applyDefaults()
     this.loadSettings()
     this.initAriaValueText()
 
@@ -158,12 +158,39 @@ export class App {
   }
 
   private wirePlaylistPanel(): void {
-    this.playlistCloseBtn.addEventListener('click', () =>
-      this.playlistDrawer.classList.add('controls-drawer--hidden'))
-    this.playlistShowBtn.addEventListener('click', () =>
-      this.playlistDrawer.classList.remove('controls-drawer--hidden'))
-    // "Add files" button reuses the hidden fileInput so no extra dialog is needed
+    this.playlistCloseBtn.addEventListener('click', () => {
+      this.playlistDrawer.classList.remove('panel--visible')
+      this._drawerBackdrop.classList.remove('backdrop--visible')
+    })
+    this.playlistShowBtn.addEventListener('click', () => {
+      const isOpen = this.playlistDrawer.classList.contains('panel--visible')
+      this.closeAllPanels()
+      if (!isOpen) {
+        this.playlistDrawer.classList.add('panel--visible')
+        this.showBackdrop()
+      }
+    })
     this.playlistAddBtn.addEventListener('click', () => this.fileInput.click())
+
+    const clearBtn = document.getElementById('playlistClearBtn')
+    clearBtn?.addEventListener('click', () => {
+      if (!this.playlist.length) return
+      this.playlist = []
+      this._trackMeta.clear()
+      this.currentTrackIndex = -1
+      this.engine.stop()
+      this.setPlayingState(false)
+      this.renderPlaylist()
+    })
+
+    const search = document.getElementById('playlistSearch') as HTMLInputElement | null
+    search?.addEventListener('input', () => {
+      const q = search.value.toLowerCase()
+      this.playlistList.querySelectorAll<HTMLElement>('.playlist-item').forEach((li) => {
+        const name = li.querySelector('.playlist-item-name')?.textContent?.toLowerCase() ?? ''
+        li.style.display = !q || name.includes(q) ? '' : 'none'
+      })
+    })
   }
 
   private addFilesToPlaylist(files: File[]): void {
@@ -205,6 +232,15 @@ export class App {
 
   private removeTrack(index: number): void {
     this.playlist.splice(index, 1)
+    // Rebuild _trackMeta with shifted indices
+    const newMeta = new Map<number, { duration: number; key: string; bpm: number }>()
+    this._trackMeta.forEach((v, k) => {
+      if (k < index)       newMeta.set(k, v)
+      else if (k > index)  newMeta.set(k - 1, v)
+      // k === index is dropped
+    })
+    this._trackMeta = newMeta
+
     if (!this.playlist.length) {
       this.currentTrackIndex = -1
       this.engine.stop()
@@ -227,9 +263,9 @@ export class App {
     this.playlist.forEach((file, i) => {
       const li     = document.createElement('li')
       const handle = document.createElement('span')
+      const info   = document.createElement('div')
       const name   = document.createElement('span')
-      const upBtn  = document.createElement('button')
-      const dnBtn  = document.createElement('button')
+      const meta   = document.createElement('span')
       const rmBtn  = document.createElement('button')
 
       li.className = 'playlist-item'
@@ -253,24 +289,23 @@ export class App {
       })
 
       handle.className = 'playlist-drag-handle'
-      handle.textContent = '⠿'
+      handle.textContent = '☰'
       handle.setAttribute('aria-hidden', 'true')
 
+      const idx = String(i + 1).padStart(2, '0')
       name.className = 'playlist-item-name'
-      name.textContent = file.name.replace(/\.[^.]+$/, '')
+      name.textContent = `${idx}. ${file.name.replace(/\.[^.]+$/, '')}`
       name.title = file.name
 
-      upBtn.className = 'playlist-move-btn'
-      upBtn.textContent = '↑'
-      upBtn.setAttribute('aria-label', `Move ${file.name} up`)
-      upBtn.disabled = i === 0
-      upBtn.addEventListener('click', (e) => { e.stopPropagation(); this.reorderTrack(i, i - 1) })
+      const m = this._trackMeta.get(i)
+      const dur = m ? formatTime(m.duration) : '—'
+      const key = m?.key ?? '—'
+      const bpm = m ? `${Math.round(m.bpm)} BPM` : '—'
+      meta.className = 'playlist-item-meta'
+      meta.textContent = `${dur} · ${key} · ${bpm}`
 
-      dnBtn.className = 'playlist-move-btn'
-      dnBtn.textContent = '↓'
-      dnBtn.setAttribute('aria-label', `Move ${file.name} down`)
-      dnBtn.disabled = i === count - 1
-      dnBtn.addEventListener('click', (e) => { e.stopPropagation(); this.reorderTrack(i, i + 1) })
+      info.className = 'playlist-item-info'
+      info.append(name, meta)
 
       rmBtn.className = 'playlist-item-remove'
       rmBtn.setAttribute('aria-label', `Remove ${file.name}`)
@@ -278,7 +313,7 @@ export class App {
       rmBtn.addEventListener('click', (e) => { e.stopPropagation(); this.removeTrack(i) })
 
       li.addEventListener('click', () => void this.switchTrack(i, true))
-      li.append(handle, name, upBtn, dnBtn, rmBtn)
+      li.append(handle, info, rmBtn)
       this.playlistList.appendChild(li)
     })
   }
@@ -294,62 +329,135 @@ export class App {
     } else if (from > this.currentTrackIndex && to <= this.currentTrackIndex) {
       this.currentTrackIndex++
     }
+    // Rebuild _trackMeta: apply the same splice to a meta array then re-index
+    const metaArr = Array.from({ length: this.playlist.length + 1 }, (_, k) =>
+      this._trackMeta.get(k) ?? null)
+    const [movedMeta] = metaArr.splice(from, 1)
+    metaArr.splice(to, 0, movedMeta)
+    this._trackMeta = new Map()
+    metaArr.forEach((v, k) => { if (v) this._trackMeta.set(k, v) })
     this.renderPlaylist()
   }
 
   private wireHelpModal(): void {
     this.helpBtn.addEventListener('click', () => this.helpModal.showModal())
     this.helpCloseBtn.addEventListener('click', () => this.helpModal.close())
-    // Click outside the dialog content to close (the <dialog> element fills the
-    // viewport; a click on it but not on its child content means the backdrop)
     this.helpModal.addEventListener('click', (e) => {
       if (e.target === this.helpModal) this.helpModal.close()
     })
-  }
-
-  private wireControlsPanel(): void {
-    this.controlsFloatBtn.addEventListener('click', () => {
-      const isNowFloating = this.controlsDrawer.classList.toggle('controls-drawer--floating')
-      this.controlsFloatBtn.setAttribute('title',      isNowFloating ? 'Pin panel'   : 'Float panel')
-      this.controlsFloatBtn.setAttribute('aria-label', isNowFloating ? 'Pin panel'   : 'Float panel')
-    })
-    this.controlsCloseBtn.addEventListener('click', () => {
-      this.controlsDrawer.classList.add('controls-drawer--hidden')
-      this.controlsDrawer.classList.remove('controls-drawer--floating')
-      this.controlsShowBtn.style.display = ''
-    })
-    this.controlsShowBtn.addEventListener('click', () => {
-      this.controlsDrawer.classList.remove('controls-drawer--hidden')
-      this.controlsShowBtn.style.display = 'none'
-      // Close effects drawer if open
-      this.effectsDrawer.classList.add('controls-drawer--hidden')
-      this.effectsShowBtn.style.display = ''
+    // Tab switching
+    const tabs = this.helpModal.querySelectorAll<HTMLButtonElement>('.help-tab')
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((t) => {
+          t.classList.remove('help-tab--active')
+          t.setAttribute('aria-selected', 'false')
+        })
+        tab.classList.add('help-tab--active')
+        tab.setAttribute('aria-selected', 'true')
+        this.helpModal.querySelectorAll<HTMLElement>('.help-tab-panel').forEach((p) => {
+          p.classList.toggle('help-tab-panel--hidden', p.id !== `helpTab-${tab.dataset.tab}`)
+        })
+      })
     })
   }
 
-  private wireEffectsPanel(): void {
-    this.effectsCloseBtn.addEventListener('click', () => {
-      this.effectsDrawer.classList.add('controls-drawer--hidden')
-      this.effectsShowBtn.style.display = ''
+  private closeAllPanels(): void {
+    this.playlistDrawer.classList.remove('panel--visible')
+    this.soundDrawer.classList.remove('panel--visible')
+    this.settingsDrawer.classList.remove('panel--visible')
+    this.soundShowBtn.classList.remove('btn-controls-show--active')
+    this.settingsShowBtn.classList.remove('btn-settings-show--active')
+    this._drawerBackdrop.classList.remove('backdrop--visible')
+  }
+
+  private showBackdrop(): void {
+    if (this._isMobile) this._drawerBackdrop.classList.add('backdrop--visible')
+  }
+
+  // iOS Safari does not fire input events from touch on range inputs that have
+  // -webkit-appearance:none, even with touch-action:none set in CSS.
+  // This method adds touch→value bridge listeners to every .slider so dragging
+  // on mobile produces the same input events as mouse drag on desktop.
+  private wireSliderTouch(): void {
+    // Touch Events are more reliable than Pointer Events for <input type="range">
+    // on iOS Safari. iOS has a native range gesture handler that conflicts with
+    // setPointerCapture(). Using touchmove with { passive: false } + preventDefault
+    // takes full ownership of the touch — the browser won't try to scroll or do
+    // its own range handling.
+    document.querySelectorAll<HTMLInputElement>('.slider').forEach((slider) => {
+      const readTouch = (e: TouchEvent) => {
+        const touch = e.touches[0]
+        if (!touch) return
+        const rect  = slider.getBoundingClientRect()
+        const min   = parseFloat(slider.min  || '0')
+        const max   = parseFloat(slider.max  || '100')
+        const step  = parseFloat(slider.step || '1')
+        const ratio = Math.max(0, Math.min(1, (touch.clientX - rect.left) / rect.width))
+        const raw   = min + ratio * (max - min)
+        const val   = Math.max(min, Math.min(max, Math.round(raw / step) * step))
+        slider.value = String(val)
+        slider.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      // touchstart: passive ok — just record initial position, no scroll risk
+      slider.addEventListener('touchstart', readTouch, { passive: true })
+      // touchmove: NON-passive so preventDefault() can stop iOS from scrolling
+      // the drawer while the user drags a slider horizontally
+      slider.addEventListener('touchmove', (e: TouchEvent) => {
+        e.preventDefault()
+        readTouch(e)
+      }, { passive: false })
     })
-    this.effectsShowBtn.addEventListener('click', () => {
-      this.effectsDrawer.classList.remove('controls-drawer--hidden')
-      this.effectsShowBtn.style.display = 'none'
-      // Close controls drawer if open
-      this.controlsDrawer.classList.add('controls-drawer--hidden')
-      this.controlsDrawer.classList.remove('controls-drawer--floating')
-      this.controlsShowBtn.style.display = ''
+  }
+
+  private wireSoundPanel(): void {
+    this.soundShowBtn.addEventListener('click', () => {
+      const isOpen = this.soundDrawer.classList.contains('panel--visible')
+      this.closeAllPanels()
+      if (!isOpen) {
+        this.soundDrawer.classList.add('panel--visible')
+        this.soundShowBtn.classList.add('btn-controls-show--active')
+        this.showBackdrop()
+      }
+    })
+    this.soundCloseBtn.addEventListener('click', () => {
+      this.soundDrawer.classList.remove('panel--visible')
+      this.soundShowBtn.classList.remove('btn-controls-show--active')
+      this._drawerBackdrop.classList.remove('backdrop--visible')
+    })
+    this.soundDrawer.querySelectorAll<HTMLButtonElement>('.sound-tab').forEach((tab) => {
+      tab.addEventListener('click', () =>
+        this.switchSoundTab(tab.dataset.tab as 'audio' | 'effects'))
+    })
+  }
+
+  private switchSoundTab(tab: 'audio' | 'effects'): void {
+    this.soundDrawer.querySelectorAll<HTMLElement>('.sound-tab').forEach((t) => {
+      const isActive = t.dataset.tab === tab
+      t.classList.toggle('sound-tab--active', isActive)
+      t.setAttribute('aria-selected', String(isActive))
+    })
+    this.soundDrawer.querySelectorAll<HTMLElement>('.sound-tab-panel').forEach((p) => {
+      p.classList.toggle('sound-tab-panel--hidden', p.id !== `soundTab-${tab}`)
     })
   }
 
   private wireSettingsPanel(): void {
     this.settingsCloseBtn.addEventListener('click', () => {
-      this.settingsDrawer.classList.add('settings-drawer--hidden')
+      this.settingsDrawer.classList.remove('panel--visible')
       this.settingsShowBtn.classList.remove('btn-settings-show--active')
+      this._drawerBackdrop.classList.remove('backdrop--visible')
     })
     this.settingsShowBtn.addEventListener('click', () => {
-      const isHidden = this.settingsDrawer.classList.toggle('settings-drawer--hidden')
-      this.settingsShowBtn.classList.toggle('btn-settings-show--active', !isHidden)
+      const isOpen = this.settingsDrawer.classList.contains('panel--visible')
+      if (isOpen) {
+        this.settingsDrawer.classList.remove('panel--visible')
+        this.settingsShowBtn.classList.remove('btn-settings-show--active')
+      } else {
+        this.settingsDrawer.classList.add('panel--visible')
+        this.settingsShowBtn.classList.add('btn-settings-show--active')
+        this.showBackdrop()
+      }
     })
     this.settingsDrawer.querySelectorAll<HTMLButtonElement>('.theme-chip').forEach((chip) => {
       chip.addEventListener('click', () => {
@@ -368,6 +476,21 @@ export class App {
     }
     this.presets.onThemeApplied = (theme: string) => {
       this.applyTheme(theme)
+    }
+    this.presets.onVisualApplied = (visual) => {
+      if (visual.reactivity    !== undefined) { this.orbReactivitySlider.value = String(Math.round(visual.reactivity * 100));       this.orbReactivityValue.textContent = `${Math.round(visual.reactivity * 100)}%`;    this.sphere?.setReactivity(visual.reactivity) }
+      if (visual.glow          !== undefined) { this.orbGlowSlider.value       = String(Math.round(visual.glow * 100));             this.orbGlowValue.textContent       = `${Math.round(visual.glow * 100)}%`;          this.sphere?.setGlow(visual.glow) }
+      if (visual.orbSize       !== undefined) { this.orbSizeSlider.value        = String(Math.round(visual.orbSize * 100));          this.orbSizeValue.textContent        = `${Math.round(visual.orbSize * 100)}%`;        this.sphere?.setOrbSize(visual.orbSize) }
+      if (visual.rotationSpeed !== undefined) { this.rotationSpeedSlider.value  = String(Math.round(visual.rotationSpeed * 100));    this.rotationSpeedValue.textContent  = `${visual.rotationSpeed.toFixed(1)}×`;         this.sphere?.setRotationSpeed(visual.rotationSpeed) }
+      if (visual.stars         !== undefined) { this.starsSlider.value          = String(Math.round(visual.stars * 100));            this.starsValue.textContent          = `${Math.round(visual.stars * 100)}%`;          this.sphere?.setStarBrightness(visual.stars) }
+      if (visual.particleCount !== undefined) { this.particleCountSlider.value  = String(visual.particleCount);                      this.particleCountValue.textContent  = String(visual.particleCount);                   this.sphere?.setParticleCount(visual.particleCount) }
+      if (visual.wireframe     !== undefined) { this.wireframeToggle.checked    = visual.wireframe;    this.sphere?.setWireframe(visual.wireframe) }
+      if (visual.bassPulse     !== undefined) { this.bassPulseToggle.checked    = visual.bassPulse;    this.sphere?.setBassPulse(visual.bassPulse) }
+      if (visual.lightning     !== undefined) { this.lightningToggle.checked    = visual.lightning;    this.sphere?.setLightning(visual.lightning) }
+      if (visual.crack         !== undefined) { this.crackToggle.checked        = visual.crack;        this.sphere?.setCrack(visual.crack) }
+      if (visual.crystal       !== undefined) { this.crystalToggle.checked      = visual.crystal;      this.sphere?.setCrystal(visual.crystal) }
+      if (visual.glitch        !== undefined) { this.glitchToggle.checked       = visual.glitch;       this.sphere?.setGlitch(visual.glitch) }
+      this.saveSettings()
     }
     this.effects.onChanged = () => {
       this.presets.clearActive()
@@ -662,6 +785,35 @@ export class App {
         case 'F':
           ;(document.getElementById('fullscreenBtn') as HTMLButtonElement | null)?.click()
           break
+        case 'n':
+        case 'N':
+          if (this.currentTrackIndex < this.playlist.length - 1)
+            void this.switchTrack(this.currentTrackIndex + 1, true)
+          break
+        case 'p':
+        case 'P':
+          if (this.currentTrackIndex > 0)
+            void this.switchTrack(this.currentTrackIndex - 1, true)
+          break
+        case '1': case '2': case '3': case '4': case '5': {
+          const idx = parseInt(e.key) - 1
+          const presetBtn = document.querySelectorAll<HTMLButtonElement>('.preset-card')[idx]
+          presetBtn?.click()
+          break
+        }
+      }
+    })
+    // Volume shortcuts — work without a file loaded
+    document.addEventListener('keydown', (e) => {
+      if ((e.target as HTMLElement).tagName === 'INPUT') return
+      if (e.key === '[') {
+        const v = Math.max(0, parseInt(this.volumeSlider.value) - 10)
+        this.volumeSlider.value = String(v)
+        this.volumeSlider.dispatchEvent(new Event('input'))
+      } else if (e.key === ']') {
+        const v = Math.min(100, parseInt(this.volumeSlider.value) + 10)
+        this.volumeSlider.value = String(v)
+        this.volumeSlider.dispatchEvent(new Event('input'))
       }
     })
   }
@@ -730,6 +882,19 @@ export class App {
       this._detectedKey = detectKey(this.engine.getBuffer()!)
       this.updateBpmDisplay()
 
+      // Store metadata for the current playlist track and refresh the playlist
+      // so the duration/key/BPM row updates from "—" to real values.
+      if (this.currentTrackIndex >= 0) {
+        this._trackMeta.set(this.currentTrackIndex, {
+          duration: this.engine.duration,
+          key:      this._detectedKey
+            ? `${NOTE_NAMES[this._detectedKey.root]} ${this._detectedKey.mode}`
+            : '—',
+          bpm:      this._baseBpm,
+        })
+        this.renderPlaylist()
+      }
+
       this.trackMeta.textContent = `${formatTime(this.engine.duration)} · ${formatBytes(file.size)} · ${file.type || 'audio'}`
       this.durationEl.textContent = formatTime(this.engine.duration)
       this.currentTimeEl.textContent = '0:00'
@@ -747,10 +912,12 @@ export class App {
           this.engine.analyserNode,
         )
         this.sphere.onEnergyUpdate = (bass, mid, treble, uiBass, uiTreble) => {
-          // On mobile, aurora vars trigger full style-recalc + compositor repaint on every
-          // backdrop-filter layer (6+). Throttle to every 3rd frame to cut repaint pressure
-          // from 60/s → 20/s — the primary fix for iOS OOM crashes during long playback.
-          if (!this._isMobile || ++this._auroraFrameN % 3 === 0) {
+          // On mobile, skip CSS var updates entirely — setProperty() on aurora vars
+          // triggers a full style-recalc + GPU compositor repaint on every
+          // backdrop-filter layer (6+) each frame, which is the primary cause of
+          // iOS OOM crashes during long playback. The aurora animates via @keyframes
+          // on mobile instead (see main.css .aurora-idle).
+          if (!this._isMobile) {
             const root = document.documentElement.style
             root.setProperty('--aurora-bass',   String(bass.toFixed(3)))
             root.setProperty('--aurora-mid',    String(mid.toFixed(3)))
@@ -820,6 +987,63 @@ export class App {
 
     this.roomSlider.setAttribute('aria-valuetext', `${this.roomSlider.value}%`)
     this.volumeSlider.setAttribute('aria-valuetext', `${this.volumeSlider.value}%`)
+  }
+
+  // Apply defaults.ts values to all sliders and engine state.
+  // Runs before loadSettings() so user-saved localStorage always wins.
+  private applyDefaults(): void {
+    const d = DEFAULTS
+
+    this.applyTheme(d.colorTheme)
+
+    this.speedSlider.value       = String(Math.round(d.speed * 100))
+    this.speedValue.textContent  = `${d.speed.toFixed(2)}x`
+    this.engine.setPlaybackRate(d.speed)
+
+    this.pitchSlider.value       = String(d.pitch)
+    this.pitchValue.textContent  = d.pitch === 0 ? '0 st' : `${d.pitch > 0 ? '+' : ''}${d.pitch} st`
+    this.engine.setPitch(d.pitch)
+
+    this.reverbSlider.value      = String(Math.round(d.reverbMix * 100))
+    this.reverbValue.textContent = `${Math.round(d.reverbMix * 100)}%`
+    this.engine.setReverbMix(d.reverbMix)
+
+    this.decaySlider.value       = String(Math.round(d.reverbDecay * 10))
+    this.decayValue.textContent  = `${d.reverbDecay.toFixed(1)}s`
+    this.engine.setReverbDecay(d.reverbDecay)
+
+    this.roomSlider.value        = String(Math.round(d.reverbRoomSize * 100))
+    this.roomValue.textContent   = `${Math.round(d.reverbRoomSize * 100)}%`
+    this.engine.setReverbRoomSize(d.reverbRoomSize)
+
+    this.volumeSlider.value      = String(Math.round(d.volume * 100))
+    this.volumeValue.textContent = `${Math.round(d.volume * 100)}%`
+    this.engine.setVolume(d.volume)
+
+    this.orbReactivitySlider.value      = String(Math.round(d.reactivity * 100))
+    this.orbReactivityValue.textContent = `${Math.round(d.reactivity * 100)}%`
+
+    this.orbGlowSlider.value      = String(Math.round(d.glow * 100))
+    this.orbGlowValue.textContent = `${Math.round(d.glow * 100)}%`
+
+    this.orbSizeSlider.value      = String(Math.round(d.orbSize * 100))
+    this.orbSizeValue.textContent = `${Math.round(d.orbSize * 100)}%`
+
+    this.rotationSpeedSlider.value      = String(Math.round(d.rotationSpeed * 100))
+    this.rotationSpeedValue.textContent = `${d.rotationSpeed.toFixed(1)}×`
+
+    this.particleCountSlider.value      = String(d.particleCount)
+    this.particleCountValue.textContent = String(d.particleCount)
+
+    this.starsSlider.value      = String(Math.round(d.stars * 100))
+    this.starsValue.textContent = `${Math.round(d.stars * 100)}%`
+
+    this.wireframeToggle.checked  = d.wireframe
+    this.bassPulseToggle.checked  = d.bassPulse
+    this.lightningToggle.checked  = d.lightning
+    this.crackToggle.checked      = d.crack
+    this.crystalToggle.checked    = d.crystal
+    this.glitchToggle.checked     = d.glitch
   }
 
   private saveSettings(): void {

--- a/src/ui/PresetController.ts
+++ b/src/ui/PresetController.ts
@@ -1,15 +1,16 @@
 import type { AudioEngine } from '../audio/AudioEngine'
 import { PRESETS } from '../presets'
-import type { AudioParams } from '../types'
+import type { AudioParams, VisualParams } from '../types'
 
-// Manages the preset strip buttons and fires onPresetApplied
-// so App.ts can sync all sliders.
+// Manages the preset strip buttons and fires onPresetApplied / onVisualApplied
+// so App.ts can sync all sliders and sphere state.
 export class PresetController {
   private engine: AudioEngine
   private buttons: NodeListOf<HTMLButtonElement>
 
-  public onPresetApplied: ((params: AudioParams) => void) | null = null
-  public onThemeApplied: ((theme: string) => void) | null = null
+  public onPresetApplied:  ((params: AudioParams)  => void) | null = null
+  public onThemeApplied:   ((theme: string)         => void) | null = null
+  public onVisualApplied:  ((visual: VisualParams)  => void) | null = null
 
   constructor(engine: AudioEngine) {
     this.engine = engine
@@ -36,7 +37,8 @@ export class PresetController {
         this.engine.applyPreset(preset.params)
         this.setActive(btn)
         this.onPresetApplied?.(preset.params)
-        if (preset.theme) this.onThemeApplied?.(preset.theme)
+        if (preset.theme)  this.onThemeApplied?.(preset.theme)
+        if (preset.visual) this.onVisualApplied?.(preset.visual)
       })
     })
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   base: './',
-  plugins: [],
+  plugins: [tailwindcss()],
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary

- **Sound UI consolidation:** Merged the separate Controls and Effects drawers into a single tabbed Sound drawer (Audio / Effects tabs), reducing toolbar clutter and giving each section a dedicated scrollable area
- **Preset visual config:** Added `VisualParams` type and per-preset `visual` blocks so each preset (Lo-Fi, Vaporwave, Ambient, Hyperpop) now drives both audio and sphere visuals on selection — wired via a new `PresetController.onVisualApplied` callback
- **iOS/mobile fixes:** Touch→input bridge on all sliders, `dvh` viewport units in drawer heights, tap-to-close backdrop, and a fully cancelling RAF loop on tab hide/show

## Changes in detail

### UI / Drawers
- Replaced separate Controls + Effects drawers with a unified **Sound drawer** containing Audio and Effects tabs
- All drawers now animate in/out with **opacity + translateX/Y slide transitions** instead of `display:none` — includes `prefers-reduced-motion` override and mobile bottom-sheet (slide-up) variant
- `closeAllPanels()` utility ensures only one drawer is open at a time
- `src/config/defaults.ts` (new) — single source of truth for every default setting value

### Presets
- New `VisualParams` interface: `reactivity`, `glow`, `orbSize`, `rotationSpeed`, `stars`, `particleCount`, and effect booleans (`wireframe`, `lightning`, `crack`, `crystal`, `glitch`)
- All four presets carry tuned visual configs that fire on selection
- `PresetDefinition.visual` is optional — omitting it falls back to defaults

### Playlist
- **Search input** filters tracks live by filename
- **Clear All** button stops playback and empties the list
- Per-track **metadata row** showing duration · detected key · BPM
- Fixed `_trackMeta` index drift on remove and reorder operations
- Replaced ↑/↓ move buttons with drag-handle-only layout

### AnomalySphere / WebGL
- Added `uWireframe` uniform — wireframe mode uses a flat high-brightness shading path so mesh edges are crisp and neon-bright instead of near-invisible
- RAF loop now **fully cancels** on `visibilitychange → hidden` and restarts on visible, preventing unbounded GPU/JS work in backgrounded tabs
- Fixed iOS VRAM leak: particle geometry rebuild disposes the old `BufferGeometry` before replacing it
- Full GPU teardown in `destroy()`: mesh, particles, stars, composer render targets, `forceContextLoss()` before `renderer.dispose()`

### Mobile / iOS
- Touch→input bridge on all `.slider` elements using non-passive `touchmove` + `preventDefault()` to fix iOS Safari range drag inside scrollable containers
- Switched drawer heights to `dvh` + definite `height` so flex scroll bodies get a real parent height on mobile