### PR TITLE
feat(audio): expanded reverb engine — 6 room types, generated IRs, decay/pre-delay/damping controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,6 +537,20 @@
                 <div class="control-section-label">Reverb</div>
                 <div class="control-group">
                   <div class="control-header">
+                    <label>Type</label>
+                    <span class="value-badge value-badge--teal" id="reverbTypeValue">Room</span>
+                  </div>
+                  <div class="btn-reverb-type-group" role="group" aria-label="Reverb room type">
+                    <button class="btn-reverb-type btn-reverb-type--active" data-reverb-type="room"    aria-pressed="true">Room</button>
+                    <button class="btn-reverb-type" data-reverb-type="hall"    aria-pressed="false">Hall</button>
+                    <button class="btn-reverb-type" data-reverb-type="plate"   aria-pressed="false">Plate</button>
+                    <button class="btn-reverb-type" data-reverb-type="church"  aria-pressed="false">Church</button>
+                    <button class="btn-reverb-type" data-reverb-type="chamber" aria-pressed="false">Chamber</button>
+                    <button class="btn-reverb-type" data-reverb-type="spring"  aria-pressed="false">Spring</button>
+                  </div>
+                </div>
+                <div class="control-group">
+                  <div class="control-header">
                     <label for="reverbSlider">Mix</label>
                     <span class="value-badge" id="reverbValue">20%</span>
                   </div>
@@ -547,14 +561,22 @@
                     <label for="decaySlider">Decay</label>
                     <span class="value-badge" id="decayValue">2.5s</span>
                   </div>
-                  <input type="range" id="decaySlider" class="slider slider--teal" min="5" max="80" value="25" step="1" aria-label="Reverb decay" />
+                  <input type="range" id="decaySlider" class="slider slider--teal" min="2" max="100" value="25" step="1" aria-label="Reverb decay" />
                 </div>
                 <div class="control-group">
                   <div class="control-header">
-                    <label for="roomSlider">Room Size</label>
-                    <span class="value-badge" id="roomValue">50%</span>
+                    <label for="preDelaySlider">Pre-delay</label>
+                    <span class="value-badge" id="preDelayValue">5 ms</span>
                   </div>
-                  <input type="range" id="roomSlider" class="slider slider--teal" min="1" max="100" value="50" step="1" aria-label="Room size" />
+                  <input type="range" id="preDelaySlider" class="slider slider--teal" min="0" max="80" value="5" step="1" aria-label="Reverb pre-delay" />
+                  <div class="slider-ticks"><span>0 ms</span><span>40 ms</span><span>80 ms</span></div>
+                </div>
+                <div class="control-group">
+                  <div class="control-header">
+                    <label for="dampingSlider">Damping</label>
+                    <span class="value-badge" id="dampingValue">35%</span>
+                  </div>
+                  <input type="range" id="dampingSlider" class="slider slider--teal" min="0" max="100" value="35" step="1" aria-label="Reverb damping" />
                 </div>
               </div>
             </div>

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -1,25 +1,78 @@
 import { EffectsChain } from './EffectsChain'
-import type { AudioParams } from '../types'
+import type { AudioParams, ReverbType } from '../types'
 
 export const MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024
 
-// Builds an exponential-decay noise IR that models room acoustics.
-// Extracted to module scope so Exporter.ts can use it without importing AudioEngine.
-export function buildIR(ctx: BaseAudioContext, decay: number, size: number): AudioBuffer {
-  const sr = ctx.sampleRate
-  const len = Math.floor(sr * Math.max(0.1, decay))
-  const ir = ctx.createBuffer(2, len, sr)
-  const decayRate = 3.0 / (decay * (0.15 + size * 0.85))
+// Per-type base damping offsets — each type has an inherent brightness character
+// independent of the user's Damping slider.
+const TYPE_DAMP_BASE: Record<ReverbType, number> = {
+  room:    0.05,
+  hall:    0.15,
+  plate:  -0.05,
+  church:  0.10,
+  chamber: 0.00,
+  spring:  0.20,
+}
 
-  // Pre-compute per-sample decay multiplier: envelope[i] = exp(-decayRate * i / sr)
-  // Using multiplicative decay avoids a division and Math.exp call per sample,
-  // reducing computation by ~3-5x for long IRs (e.g. Ambient 4.4s ≈ 422k samples).
+// Per-type decay rate scale — affects how quickly the tail fades.
+const TYPE_DECAY_SCALE: Record<ReverbType, number> = {
+  room:    1.00,
+  hall:    0.85,
+  plate:   1.10,
+  church:  0.70,
+  chamber: 1.20,
+  spring:  1.00,
+}
+
+// Builds a synthetic IR for the given reverb type.
+// Extracted to module scope so Exporter.ts can use it without importing AudioEngine.
+export function buildIR(
+  ctx: BaseAudioContext,
+  type: ReverbType,
+  decay: number,
+  preDelay: number,   // seconds, 0–0.08
+  damping: number,    // 0.0–1.0
+): AudioBuffer {
+  const sr = ctx.sampleRate
+  const preDelaySamples = Math.floor(sr * Math.max(0, preDelay))
+  const tailSamples = Math.floor(sr * Math.max(0.1, decay))
+  const totalLen = preDelaySamples + tailSamples
+
+  const ir = ctx.createBuffer(2, totalLen, sr)
+
+  // decayRate drives the exponential envelope; scaled per type so types sound
+  // characteristically longer or shorter at the same Decay slider value.
+  const scale = TYPE_DECAY_SCALE[type]
+  const decayRate = (3.0 / Math.max(0.1, decay)) * scale
+
+  // LP coefficient: higher = darker/more damped. Clamped below 0.98 so the
+  // filter doesn't fully freeze. Combined type offset + user damping param.
+  const lpCoeff = Math.max(0, Math.min(0.98, TYPE_DAMP_BASE[type] + damping * 0.85))
+
+  // Spring reverb: add a sinusoidal resonance at ~12 Hz to create the metallic
+  // boing — this frequency sits above audible but aliases into the tail as
+  // a repeating amplitude pattern, similar to a physical spring coil.
+  const springFreq = type === 'spring' ? (2 * Math.PI * 12) / sr : 0
+
+  // Pre-compute multiplicative decay multiplier to avoid Math.exp per sample.
   const expDecayPerSample = Math.exp(-decayRate / sr)
+
   for (let ch = 0; ch < 2; ch++) {
     const data = ir.getChannelData(ch)
+    // Pre-delay region: silence
+    for (let i = 0; i < preDelaySamples; i++) {
+      data[i] = 0
+    }
+    // IR tail: exponential-decay noise passed through a 1-pole IIR LP filter
     let envelope = 1.0
-    for (let i = 0; i < len; i++) {
-      data[i] = (Math.random() * 2 - 1) * envelope
+    let lpState = 0
+    for (let i = 0; i < tailSamples; i++) {
+      const noise = Math.random() * 2 - 1
+      // 1-pole IIR low-pass: lpState smooths toward the noise input
+      lpState = lpState * lpCoeff + noise * (1 - lpCoeff)
+      let sample = lpState * envelope
+      if (springFreq > 0) sample *= Math.sin(springFreq * i)
+      data[preDelaySamples + i] = sample
       envelope *= expDecayPerSample
     }
   }
@@ -67,15 +120,17 @@ export class AudioEngine {
   private _sourceGeneration = 0
 
   // State
-  private _playbackRate = 1.0
-  private _pitchSemitones = 0
-  private _reverbMix = 0.2
-  private _volume = 0.8
-  private _reverbDecay = 2.5
-  private _reverbRoomSize = 0.5
-  private _isPlaying = false
+  private _playbackRate    = 1.0
+  private _pitchSemitones  = 0
+  private _reverbMix       = 0.2
+  private _volume          = 0.8
+  private _reverbDecay     = 2.5
+  private _reverbType:     ReverbType = 'room'
+  private _reverbPreDelay  = 0.005   // seconds
+  private _reverbDamping   = 0.35
+  private _isPlaying       = false
   private _startContextTime = 0
-  private _startOffset = 0
+  private _startOffset     = 0
 
   // Loop region
   private _loopEnabled  = false
@@ -124,15 +179,17 @@ export class AudioEngine {
 
   getParams(): AudioParams {
     return {
-      playbackRate: this._playbackRate,
-      reverbMix: this._reverbMix,
-      reverbDecay: this._reverbDecay,
-      reverbRoomSize: this._reverbRoomSize,
-      volume: this._volume,
-      eq: { ...this._eq },
-      chorus: { ...this._chorus },
+      playbackRate:   this._playbackRate,
+      reverbMix:      this._reverbMix,
+      reverbDecay:    this._reverbDecay,
+      reverbType:     this._reverbType,
+      reverbPreDelay: this._reverbPreDelay,
+      reverbDamping:  this._reverbDamping,
+      volume:         this._volume,
+      eq:             { ...this._eq },
+      chorus:         { ...this._chorus },
       saturationDrive: this._saturationDrive,
-      hzFrequency: this._hzFrequency,
+      hzFrequency:    this._hzFrequency,
       pitchSemitones: this._pitchSemitones,
     }
   }
@@ -177,7 +234,10 @@ export class AudioEngine {
     this.wetGainNode.connect(this.masterGainNode)
 
     try {
-      this.convolverNode.buffer = buildIR(this.context, this._reverbDecay, this._reverbRoomSize)
+      this.convolverNode.buffer = buildIR(
+        this.context, this._reverbType, this._reverbDecay,
+        this._reverbPreDelay, this._reverbDamping,
+      )
     } catch (err) {
       console.error('ensureContext: buildIR failed (NaN or invalid params?)', err)
     }
@@ -375,17 +435,27 @@ export class AudioEngine {
   }
 
   setReverbDecay(decaySeconds: number): void {
-    this._reverbDecay = Math.max(0.1, Math.min(8.0, decaySeconds))
+    this._reverbDecay = Math.max(0.2, Math.min(10.0, decaySeconds))
     this._scheduleRebuildIR()
   }
 
-  setReverbRoomSize(size: number): void {
-    this._reverbRoomSize = Math.max(0.01, Math.min(1.0, size))
+  setReverbType(type: ReverbType): void {
+    this._reverbType = type
+    this._scheduleRebuildIR()
+  }
+
+  setReverbPreDelay(seconds: number): void {
+    this._reverbPreDelay = Math.max(0, Math.min(0.08, seconds))
+    this._scheduleRebuildIR()
+  }
+
+  setReverbDamping(damping: number): void {
+    this._reverbDamping = Math.max(0, Math.min(1, damping))
     this._scheduleRebuildIR()
   }
 
   // Defers rebuildIR() to the next animation frame so that rapid back-to-back
-  // calls (e.g. applyPreset sets both decay and roomSize in the same tick) only
+  // calls (e.g. applyPreset sets multiple reverb params in the same tick) only
   // trigger one allocation and one ConvolverNode buffer replacement.
   private _scheduleRebuildIR(): void {
     if (this._irRafId !== null) return
@@ -437,8 +507,10 @@ export class AudioEngine {
   applyPreset(params: AudioParams): void {
     this.setPlaybackRate(params.playbackRate)
     this.setReverbMix(params.reverbMix)
+    this.setReverbType(params.reverbType)
     this.setReverbDecay(params.reverbDecay)
-    this.setReverbRoomSize(params.reverbRoomSize)
+    this.setReverbPreDelay(params.reverbPreDelay)
+    this.setReverbDamping(params.reverbDamping)
     this.setVolume(params.volume)
     this.setEQ('low',     params.eq.low)
     this.setEQ('lowMid',  params.eq.lowMid)
@@ -547,7 +619,10 @@ export class AudioEngine {
   private rebuildIR(): void {
     if (!this.convolverNode || !this.context) return
     try {
-      this.convolverNode.buffer = buildIR(this.context, this._reverbDecay, this._reverbRoomSize)
+      this.convolverNode.buffer = buildIR(
+        this.context, this._reverbType, this._reverbDecay,
+        this._reverbPreDelay, this._reverbDamping,
+      )
     } catch (err) {
       console.error('rebuildIR: failed to create IR buffer (OOM or closed context)', err)
     }

--- a/src/audio/Exporter.ts
+++ b/src/audio/Exporter.ts
@@ -33,7 +33,7 @@ export async function exportAudio(engine: AudioEngine, trackName: string): Promi
   source.playbackRate.value = params.playbackRate
 
   const convolver = offline.createConvolver()
-  convolver.buffer = buildIR(offline, params.reverbDecay, params.reverbRoomSize)
+  convolver.buffer = buildIR(offline, params.reverbType, params.reverbDecay, params.reverbPreDelay, params.reverbDamping)
 
   const dryGain = offline.createGain()
   dryGain.gain.value = 1 - params.reverbMix

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -23,8 +23,10 @@ export const DEFAULTS = {
 
   // ── Reverb ───────────────────────────────────────────────────────────────────
   reverbMix:      0.20,   // wet/dry mix    [0.00 – 1.00]
-  reverbDecay:    2.5,    // tail length    [0.50 – 8.00] seconds
-  reverbRoomSize: 0.50,   // room size      [0.00 – 1.00]
+  reverbDecay:    2.5,    // tail length    [0.20 – 10.00] seconds
+  reverbType:     'room' as import('../types').ReverbType,
+  reverbPreDelay: 0.005,  // pre-delay      [0.000 – 0.080] seconds (0–80 ms)
+  reverbDamping:  0.35,   // HF damping     [0.00 – 1.00]
 
   // ── Orb Visuals ──────────────────────────────────────────────────────────────
   reactivity:     0.80,   // beat response  [0.00 – 1.00]

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -12,8 +12,10 @@
 // AUDIO RANGES (params)
 //   playbackRate             0.50 – 1.70   (1.0 = normal speed)
 //   reverbMix                0.00 – 1.00   (0 = dry, 1 = full wet)
-//   reverbDecay              0.50 – 8.00   seconds
-//   reverbRoomSize           0.00 – 1.00
+//   reverbDecay              0.20 – 10.00  seconds
+//   reverbType               room | hall | plate | church | chamber | spring
+//   reverbPreDelay           0.000 – 0.080 seconds (0–80 ms)
+//   reverbDamping            0.00 – 1.00
 //   volume                   0.00 – 1.00
 //   eq.low/lowMid/mid/highMid/high  -12 – +12  dB
 //   chorus.rate              0.10 – 5.00   Hz
@@ -55,7 +57,9 @@ export const PRESETS: PresetDefinition[] = [
       playbackRate:    0.78,
       reverbMix:       0.47,
       reverbDecay:     2.5,
-      reverbRoomSize:  0.68,
+      reverbType:      'room',
+      reverbPreDelay:  0.010,
+      reverbDamping:   0.50,
       volume:          0.80,
       eq:              { low: 3, lowMid: 1.5, mid: -1, highMid: -2, high: -5 },
       chorus:          { rate: 0, depth: 0 },
@@ -85,7 +89,9 @@ export const PRESETS: PresetDefinition[] = [
       playbackRate:    0.69,
       reverbMix:       0.74,
       reverbDecay:     3.3,
-      reverbRoomSize:  0.52,
+      reverbType:      'hall',
+      reverbPreDelay:  0.020,
+      reverbDamping:   0.30,
       volume:          0.80,
       eq:              { low: 1.5, lowMid: 0.5, mid: 1, highMid: 1.5, high: 2 },
       chorus:          { rate: 0.2, depth: 0 },
@@ -115,7 +121,9 @@ export const PRESETS: PresetDefinition[] = [
       playbackRate:    0.65,
       reverbMix:       0.70,
       reverbDecay:     4.4,
-      reverbRoomSize:  0.81,
+      reverbType:      'church',
+      reverbPreDelay:  0.030,
+      reverbDamping:   0.20,
       volume:          0.75,
       eq:              { low: 0, lowMid: -1, mid: -3, highMid: -1.5, high: -2 },
       chorus:          { rate: 0.5, depth: 0.10 },
@@ -138,7 +146,7 @@ export const PRESETS: PresetDefinition[] = [
   },
 
   // ── Hyperpop ─────────────────────────────────────────────────────────────────
-  // Sped-up and chaotic. Saturation drive, scooped mids, and a tight room.
+  // Sped-up and chaotic. Saturation drive, scooped mids, and a tight plate.
   // High reactivity and crack veins for maximum visual aggression.
   {
     id:    'hyperpop',
@@ -148,7 +156,9 @@ export const PRESETS: PresetDefinition[] = [
       playbackRate:    1.25,
       reverbMix:       0.27,
       reverbDecay:     1.7,
-      reverbRoomSize:  0.59,
+      reverbType:      'plate',
+      reverbPreDelay:  0.005,
+      reverbDamping:   0.15,
       volume:          0.80,
       eq:              { low: 1, lowMid: -1.5, mid: -3.5, highMid: 2, high: 1 },
       chorus:          { rate: 0.8, depth: 0.08 },

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1689,6 +1689,47 @@ body.is-paused .site-footer {
   box-shadow: 0 0 8px rgba(129, 140, 248, 0.25);
 }
 
+.btn-reverb-type-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.btn-reverb-type {
+  flex: 1 1 auto;
+  min-width: 44px;
+  padding: 5px 6px;
+  border: 1px solid var(--border-2);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+
+.btn-reverb-type:hover {
+  border-color: var(--teal);
+  color: var(--teal);
+  background: var(--teal-dim);
+}
+
+.btn-reverb-type:focus-visible {
+  box-shadow: 0 0 0 2px var(--teal);
+}
+
+.btn-reverb-type--active {
+  border-color: var(--teal);
+  color: var(--teal);
+  background: var(--teal-dim);
+  box-shadow: 0 0 8px rgba(0, 201, 160, 0.25);
+}
+
 .control-hint {
   margin: 4px 0 0;
   font-size: 11px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 // Shared types used across the app
 
 export type EQBand = 'low' | 'lowMid' | 'mid' | 'highMid' | 'high'
+export type ReverbType = 'room' | 'hall' | 'plate' | 'church' | 'chamber' | 'spring'
 
 export interface EQParams {
   low:     number   // dB, -12 to +12  (lowshelf  @ 80 Hz)
@@ -26,16 +27,18 @@ export interface ChorusParams {
 // All audio parameters in one flat object.
 // Used by presets and getParams/applyPreset.
 export interface AudioParams {
-  playbackRate: number      // 0.25 to 1.0
-  reverbMix: number         // 0 to 1
-  reverbDecay: number       // 0.1 to 8.0 seconds
-  reverbRoomSize: number    // 0.01 to 1.0
-  volume: number            // 0 to 1
-  eq: EQParams
-  chorus: ChorusParams
-  saturationDrive: number   // 0 to 1
-  hzFrequency: number | null  // Solfeggio resonance Hz, null = off
-  pitchSemitones: number    // -12 to +12 semitones (0 = no shift)
+  playbackRate:   number       // 0.50 to 1.70
+  reverbMix:      number       // 0 to 1
+  reverbDecay:    number       // 0.2 to 10.0 seconds
+  reverbType:     ReverbType   // room | hall | plate | church | chamber | spring
+  reverbPreDelay: number       // 0 to 0.08 seconds (0–80 ms)
+  reverbDamping:  number       // 0.0 to 1.0
+  volume:         number       // 0 to 1
+  eq:             EQParams
+  chorus:         ChorusParams
+  saturationDrive: number      // 0 to 1
+  hzFrequency:    number | null  // Solfeggio resonance Hz, null = off
+  pitchSemitones: number       // -12 to +12 semitones (0 = no shift)
 }
 
 export interface VisualParams {
@@ -60,4 +63,3 @@ export interface PresetDefinition {
   params: AudioParams
   visual?: VisualParams
 }
-

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -10,7 +10,7 @@ import { PresetController } from './PresetController'
 import { EffectsController } from './EffectsController'
 import { ExportController } from './ExportController'
 import { MobileController } from './MobileController'
-import type { AudioParams } from '../types'
+import type { AudioParams, ReverbType } from '../types'
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -57,14 +57,19 @@ export class App {
   private speedValue = document.getElementById('speedValue')!
   private pitchSlider = document.getElementById('pitchSlider') as HTMLInputElement
   private pitchValue = document.getElementById('pitchValue')!
-  private reverbSlider = document.getElementById('reverbSlider') as HTMLInputElement
-  private reverbValue = document.getElementById('reverbValue')!
-  private decaySlider = document.getElementById('decaySlider') as HTMLInputElement
-  private decayValue = document.getElementById('decayValue')!
-  private roomSlider = document.getElementById('roomSlider') as HTMLInputElement
-  private roomValue = document.getElementById('roomValue')!
-  private volumeSlider = document.getElementById('volumeSlider') as HTMLInputElement
-  private volumeValue = document.getElementById('volumeValue')!
+  private reverbSlider       = document.getElementById('reverbSlider')    as HTMLInputElement
+  private reverbValue        = document.getElementById('reverbValue')!
+  private decaySlider        = document.getElementById('decaySlider')     as HTMLInputElement
+  private decayValue         = document.getElementById('decayValue')!
+  private preDelaySlider     = document.getElementById('preDelaySlider')  as HTMLInputElement
+  private preDelayValue      = document.getElementById('preDelayValue')!
+  private dampingSlider      = document.getElementById('dampingSlider')   as HTMLInputElement
+  private dampingValue       = document.getElementById('dampingValue')!
+  private reverbTypeButtons  = Array.from(document.querySelectorAll<HTMLButtonElement>('.btn-reverb-type'))
+  private reverbTypeValue    = document.getElementById('reverbTypeValue')!
+  private _reverbType: ReverbType = 'room'
+  private volumeSlider       = document.getElementById('volumeSlider')    as HTMLInputElement
+  private volumeValue        = document.getElementById('volumeValue')!
 
   // Sound drawer refs (merged Audio + Effects)
   private soundDrawer   = document.getElementById('soundDrawer')!
@@ -624,6 +629,22 @@ export class App {
       this.saveSettings()
     })
 
+    // Reverb type chips
+    this.reverbTypeButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const t = btn.dataset.reverbType as ReverbType
+        this._reverbType = t
+        this.reverbTypeButtons.forEach(b => {
+          b.classList.toggle('btn-reverb-type--active', b === btn)
+          b.setAttribute('aria-pressed', String(b === btn))
+        })
+        this.reverbTypeValue.textContent = btn.textContent!
+        this.engine.setReverbType(t)
+        this.presets.clearActive()
+        this.saveSettings()
+      })
+    })
+
     // Reverb mix
     this.reverbSlider.addEventListener('input', () => {
       const mix = parseInt(this.reverbSlider.value) / 100
@@ -645,12 +666,22 @@ export class App {
       this.saveSettings()
     })
 
-    // Room size
-    this.roomSlider.addEventListener('input', () => {
-      const size = parseInt(this.roomSlider.value) / 100
-      this.engine.setReverbRoomSize(size)
-      this.roomValue.textContent = `${this.roomSlider.value}%`
-      this.roomSlider.setAttribute('aria-valuetext', `${this.roomSlider.value}%`)
+    // Pre-delay
+    this.preDelaySlider.addEventListener('input', () => {
+      const ms = parseInt(this.preDelaySlider.value)
+      this.engine.setReverbPreDelay(ms / 1000)
+      this.preDelayValue.textContent = `${ms} ms`
+      this.preDelaySlider.setAttribute('aria-valuetext', `${ms} milliseconds`)
+      this.presets.clearActive()
+      this.saveSettings()
+    })
+
+    // Damping
+    this.dampingSlider.addEventListener('input', () => {
+      const d = parseInt(this.dampingSlider.value) / 100
+      this.engine.setReverbDamping(d)
+      this.dampingValue.textContent = `${this.dampingSlider.value}%`
+      this.dampingSlider.setAttribute('aria-valuetext', `${this.dampingSlider.value}%`)
       this.presets.clearActive()
       this.saveSettings()
     })
@@ -962,8 +993,19 @@ export class App {
     this.decaySlider.value = String(Math.round(params.reverbDecay * 10))
     this.decayValue.textContent = `${params.reverbDecay.toFixed(1)}s`
 
-    this.roomSlider.value = String(Math.round(params.reverbRoomSize * 100))
-    this.roomValue.textContent = `${Math.round(params.reverbRoomSize * 100)}%`
+    this._reverbType = params.reverbType
+    this.reverbTypeButtons.forEach(b => {
+      const active = b.dataset.reverbType === params.reverbType
+      b.classList.toggle('btn-reverb-type--active', active)
+      b.setAttribute('aria-pressed', String(active))
+      if (active) this.reverbTypeValue.textContent = b.textContent!
+    })
+
+    this.preDelaySlider.value = String(Math.round(params.reverbPreDelay * 1000))
+    this.preDelayValue.textContent = `${Math.round(params.reverbPreDelay * 1000)} ms`
+
+    this.dampingSlider.value = String(Math.round(params.reverbDamping * 100))
+    this.dampingValue.textContent = `${Math.round(params.reverbDamping * 100)}%`
 
     this.volumeSlider.value = String(Math.round(params.volume * 100))
     this.volumeValue.textContent = `${Math.round(params.volume * 100)}%`
@@ -985,7 +1027,8 @@ export class App {
     const decay = parseInt(this.decaySlider.value) / 10
     this.decaySlider.setAttribute('aria-valuetext', `${decay.toFixed(1)} seconds`)
 
-    this.roomSlider.setAttribute('aria-valuetext', `${this.roomSlider.value}%`)
+    this.preDelaySlider.setAttribute('aria-valuetext', `${this.preDelaySlider.value} milliseconds`)
+    this.dampingSlider.setAttribute('aria-valuetext', `${this.dampingSlider.value}%`)
     this.volumeSlider.setAttribute('aria-valuetext', `${this.volumeSlider.value}%`)
   }
 
@@ -1012,9 +1055,22 @@ export class App {
     this.decayValue.textContent  = `${d.reverbDecay.toFixed(1)}s`
     this.engine.setReverbDecay(d.reverbDecay)
 
-    this.roomSlider.value        = String(Math.round(d.reverbRoomSize * 100))
-    this.roomValue.textContent   = `${Math.round(d.reverbRoomSize * 100)}%`
-    this.engine.setReverbRoomSize(d.reverbRoomSize)
+    this._reverbType = d.reverbType
+    this.reverbTypeButtons.forEach(b => {
+      const active = b.dataset.reverbType === d.reverbType
+      b.classList.toggle('btn-reverb-type--active', active)
+      b.setAttribute('aria-pressed', String(active))
+      if (active) this.reverbTypeValue.textContent = b.textContent!
+    })
+    this.engine.setReverbType(d.reverbType)
+
+    this.preDelaySlider.value      = String(Math.round(d.reverbPreDelay * 1000))
+    this.preDelayValue.textContent = `${Math.round(d.reverbPreDelay * 1000)} ms`
+    this.engine.setReverbPreDelay(d.reverbPreDelay)
+
+    this.dampingSlider.value      = String(Math.round(d.reverbDamping * 100))
+    this.dampingValue.textContent = `${Math.round(d.reverbDamping * 100)}%`
+    this.engine.setReverbDamping(d.reverbDamping)
 
     this.volumeSlider.value      = String(Math.round(d.volume * 100))
     this.volumeValue.textContent = `${Math.round(d.volume * 100)}%`
@@ -1053,7 +1109,9 @@ export class App {
       pitch:        this.pitchSlider.value,
       reverb:       this.reverbSlider.value,
       decay:        this.decaySlider.value,
-      room:         this.roomSlider.value,
+      reverbType:   this._reverbType,
+      preDelay:     this.preDelaySlider.value,
+      damping:      this.dampingSlider.value,
       volume:       this.volumeSlider.value,
       particleCount: this.particleCountSlider.value,
       orbReactivity: this.orbReactivitySlider.value,
@@ -1111,11 +1169,28 @@ export class App {
       this.decayValue.textContent = `${decay.toFixed(1)}s`
       if (isFinite(decay)) this.engine.setReverbDecay(decay)
     }
-    if (s['room'] !== undefined) {
-      this.roomSlider.value = str(s['room'], this.roomSlider.value)
-      this.roomValue.textContent = `${this.roomSlider.value}%`
-      const room = parseInt(this.roomSlider.value) / 100
-      if (isFinite(room)) this.engine.setReverbRoomSize(room)
+    if (s['reverbType'] !== undefined) {
+      const t = str(s['reverbType'], 'room') as ReverbType
+      this._reverbType = t
+      this.reverbTypeButtons.forEach(b => {
+        const active = b.dataset.reverbType === t
+        b.classList.toggle('btn-reverb-type--active', active)
+        b.setAttribute('aria-pressed', String(active))
+        if (active) this.reverbTypeValue.textContent = b.textContent!
+      })
+      this.engine.setReverbType(t)
+    }
+    if (s['preDelay'] !== undefined) {
+      this.preDelaySlider.value = str(s['preDelay'], this.preDelaySlider.value)
+      const ms = parseInt(this.preDelaySlider.value)
+      this.preDelayValue.textContent = `${ms} ms`
+      if (isFinite(ms)) this.engine.setReverbPreDelay(ms / 1000)
+    }
+    if (s['damping'] !== undefined) {
+      this.dampingSlider.value = str(s['damping'], this.dampingSlider.value)
+      this.dampingValue.textContent = `${this.dampingSlider.value}%`
+      const d = parseInt(this.dampingSlider.value) / 100
+      if (isFinite(d)) this.engine.setReverbDamping(d)
     }
     if (s['volume'] !== undefined) {
       this.volumeSlider.value = str(s['volume'], this.volumeSlider.value)


### PR DESCRIPTION
## Summary

- Replace single-mode convolution reverb with a 6-type engine: **Room, Hall, Plate, Church, Chamber, Spring**
- All IRs generated synthetically at runtime (no audio file assets) using type-specific decay scales, 1-pole IIR LP damping, and spring resonance modulation
- Remove Room Size; add **Pre-delay** (0–80 ms) and **Damping** (0–1) parameters; expand Decay range to 0.2–10 s
- Type chip selector added to Reverb UI (teal, matches Hz button style); all 4 reverb params persist to localStorage
- Updated all 4 presets with explicit reverb types (Lo-Fi→room, Vaporwave→hall, Ambient→church, Hyperpop→plate)

## Files changed

| File | Change |
|------|--------|
| `src/types.ts` | Added `ReverbType`, updated `AudioParams` |
| `src/audio/AudioEngine.ts` | Refactored `buildIR()`, new setters |
| `src/audio/Exporter.ts` | Updated `buildIR()` call signature |
| `src/config/defaults.ts` | Updated reverb defaults |
| `src/presets.ts` | Assigned reverb types, removed `reverbRoomSize` |
| `index.html` | Type chips + Pre-delay + Damping sliders |
| `src/ui/App.ts` | Wired controls, updated save/load/sync |
| `src/styles/main.css` | `.btn-reverb-type` chip styles |

## Test plan

- [x] 6 type chips render in Reverb section, active chip highlights in teal on click
- [x] IR audibly changes character across all 6 types
- [x] Decay, Pre-delay, Damping sliders all affect the reverb in real time
- [x] Mix slider still works correctly
- [ ] Applying a preset updates the type chip and all slider values
- [ ] Reload page — type + all 4 params restore from localStorage
- [ ] EQ, pitch, chorus, playback rate show no regression
- [ ] Mobile touch works on chips and sliders

Closes #82