### PR TITLE
feat(eq): DAW-style grid, spectrum ghost curves, professional EQ visualization

### DIFF
--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -97,6 +97,9 @@ export class AudioEngine {
   // Analyser tapped from effects chain output for the spectrum visualizer
   private _analyserNode: AnalyserNode | null = null
 
+  // Parallel tap before the EQ chain — used by EffectsController to show pre-EQ spectrum ghost
+  private _analyserPreEQNode: AnalyserNode | null = null
+
   // Hidden <audio> element whose srcObject is a silent MediaStream from this
   // context. Playing it keeps the iOS audio session alive in the background
   // without exposing a file duration - so Control Center shows our
@@ -174,6 +177,7 @@ export class AudioEngine {
 
   get effectsChain(): EffectsChain | null { return this._effectsChain }
   get analyserNode(): AnalyserNode | null { return this._analyserNode }
+  get analyserPreEQ(): AnalyserNode | null { return this._analyserPreEQNode }
 
   getBuffer(): AudioBuffer | null { return this.buffer }
 
@@ -241,6 +245,19 @@ export class AudioEngine {
     } catch (err) {
       console.error('ensureContext: buildIR failed (NaN or invalid params?)', err)
     }
+
+    // Pre-EQ analyser tap — parallel connection from masterGain, before the EQ chain.
+    // A silent gain (value 0) is required to keep the node active in the audio graph.
+    this._analyserPreEQNode = this.context.createAnalyser()
+    this._analyserPreEQNode.fftSize = 2048
+    this._analyserPreEQNode.smoothingTimeConstant = 0.88
+    this._analyserPreEQNode.minDecibels = -90
+    this._analyserPreEQNode.maxDecibels = -10
+    const preEQSilent = this.context.createGain()
+    preEQSilent.gain.value = 0
+    this.masterGainNode.connect(this._analyserPreEQNode)
+    this._analyserPreEQNode.connect(preEQSilent)
+    preEQSilent.connect(this.context.destination)
 
     // Effects chain sits between masterGain and destination
     this._effectsChain = new EffectsChain()

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1297,8 +1297,8 @@ export class App {
     this.playPauseBtn.setAttribute('aria-label', playing ? 'Pause' : 'Play')
     document.body.classList.toggle('is-playing', playing)
     document.body.classList.toggle('is-paused', !playing)
-    // Keep the OS lock screen transport badge in sync with the in-app state
     this._mobile?.updatePlaybackState(playing)
+    this.effects.setPlaybackState(playing)
   }
 
   private showPlayer(): void {

--- a/src/ui/EffectsController.ts
+++ b/src/ui/EffectsController.ts
@@ -95,6 +95,15 @@ export class EffectsController {
   public on8DChange: ((enabled: boolean, speed: number) => void) | null = null
   public onChanged:  (() => void) | null = null
 
+  // ── Spectrum ghost animation ──────────────────────────────────────────────
+  private _spectrumRafId: number | null = null
+  private _spectrumOpacity = 0
+  private _isPlayingAudio  = false
+  private readonly _SPECTRUM_ALPHA = 0.88  // exponential smoothing factor (calm/fluid)
+  private _preSmoothed:  Float32Array | null = null
+  private _postSmoothed: Float32Array | null = null
+  private _spectrumBins  = 0
+
   constructor(engine: AudioEngine) {
     this.engine = engine
 
@@ -574,13 +583,8 @@ export class EffectsController {
 
     ctx.clearRect(0, 0, W, H)
 
-    // 0 dB reference line
-    ctx.beginPath()
-    ctx.strokeStyle = 'rgba(255,255,255,0.06)'
-    ctx.lineWidth = 1
-    ctx.moveTo(0, H * 0.5)
-    ctx.lineTo(W, H * 0.5)
-    ctx.stroke()
+    this._drawGrid(ctx, W, H)
+    if (this._spectrumOpacity > 0.01) this._drawSpectrumGhosts(ctx, W, H)
 
     const accentRgb = this._getAccentRGB()
 
@@ -646,12 +650,233 @@ export class EffectsController {
 
   private _drawFlatCurve(ctx: CanvasRenderingContext2D, W: number, H: number): void {
     ctx.clearRect(0, 0, W, H)
+    this._drawGrid(ctx, W, H)
     ctx.beginPath()
     ctx.strokeStyle = 'rgba(255,255,255,0.15)'
     ctx.lineWidth = 1
     ctx.moveTo(0, H * 0.5)
     ctx.lineTo(W, H * 0.5)
     ctx.stroke()
+  }
+
+  // ── Grid (Ableton/Pro-Q style) ────────────────────────────────────────────
+
+  private _drawGrid(ctx: CanvasRenderingContext2D, W: number, H: number): void {
+    const toY = (db: number) => H * 0.5 - (db / this.DB_RANGE) * H * 0.45
+
+    // Horizontal dB lines
+    const dbLevels = [
+      { db: 12,  label: '+12', alpha: 0.10, dash: [3, 4] },
+      { db: 6,   label: '+6',  alpha: 0.14, dash: [3, 4] },
+      { db: 0,   label: '0',   alpha: 0.28, dash: []     },
+      { db: -6,  label: '-6',  alpha: 0.14, dash: [3, 4] },
+      { db: -12, label: '-12', alpha: 0.10, dash: [3, 4] },
+    ]
+
+    ctx.save()
+    ctx.font = '9px system-ui, sans-serif'
+    ctx.textBaseline = 'middle'
+
+    for (const level of dbLevels) {
+      const y = toY(level.db)
+      ctx.beginPath()
+      ctx.setLineDash(level.dash)
+      ctx.strokeStyle = `rgba(255,255,255,${level.alpha})`
+      ctx.lineWidth = level.db === 0 ? 1.5 : 1
+      ctx.moveTo(0, y)
+      ctx.lineTo(W, y)
+      ctx.stroke()
+      ctx.setLineDash([])
+
+      // Labels on both sides
+      ctx.fillStyle = `rgba(255,255,255,${level.alpha + 0.10})`
+      ctx.textAlign = 'left'
+      ctx.fillText(level.label, 4, y)
+      ctx.textAlign = 'right'
+      ctx.fillText(level.label, W - 4, y)
+    }
+
+    // Vertical frequency lines + labels
+    const freqMarkers = [
+      { hz: 20,    label: '20'   },
+      { hz: 50,    label: '50'   },
+      { hz: 100,   label: '100'  },
+      { hz: 200,   label: '200'  },
+      { hz: 500,   label: '500'  },
+      { hz: 1000,  label: '1k'   },
+      { hz: 2000,  label: '2k'   },
+      { hz: 5000,  label: '5k'   },
+      { hz: 10000, label: '10k'  },
+      { hz: 20000, label: '20k'  },
+    ]
+
+    ctx.font = '8px system-ui, sans-serif'
+    ctx.textBaseline = 'bottom'
+    ctx.textAlign = 'center'
+
+    for (const m of freqMarkers) {
+      const x = this._freqToX(m.hz, W)
+      ctx.beginPath()
+      ctx.setLineDash([2, 4])
+      ctx.strokeStyle = 'rgba(255,255,255,0.07)'
+      ctx.lineWidth = 1
+      ctx.moveTo(x, 0)
+      ctx.lineTo(x, H - 12)
+      ctx.stroke()
+      ctx.setLineDash([])
+
+      ctx.fillStyle = 'rgba(255,255,255,0.30)'
+      ctx.fillText(m.label, x, H)
+    }
+
+    ctx.restore()
+  }
+
+  // ── Spectrum ghosts (pre-EQ + post-EQ filled curves) ─────────────────────
+
+  private _drawSpectrumGhosts(ctx: CanvasRenderingContext2D, W: number, H: number): void {
+    if (!this._preSmoothed || !this._postSmoothed) return
+    const op = this._spectrumOpacity
+    const bins = this._spectrumBins
+    if (!bins) return
+
+    // dBFS → canvas Y: -10 dBFS (loud) = top, -90 dBFS (silence) = bottom
+    const specToY = (dBFS: number) => H - ((dBFS + 90) / 80) * H
+
+    const nyquist = (this.engine.analyserPreEQ?.context.sampleRate ?? 44100) / 2
+
+    const drawGhost = (data: Float32Array, rgb: string, fillAlpha: number, strokeAlpha: number, lineW: number) => {
+      ctx.beginPath()
+      ctx.moveTo(0, H)
+      for (let xi = 0; xi <= W; xi += 2) {
+        const hz  = this._xToFreq(xi, W)
+        const bin = Math.min(Math.floor((hz / nyquist) * bins), bins - 1)
+        const y   = specToY(data[bin])
+        ctx.lineTo(xi, y)
+      }
+      ctx.lineTo(W, H)
+      ctx.closePath()
+      ctx.fillStyle = `rgba(${rgb},${fillAlpha * op})`
+      ctx.fill()
+
+      // Stroke the top edge
+      ctx.beginPath()
+      ctx.moveTo(0, specToY(data[0]))
+      for (let xi = 2; xi <= W; xi += 2) {
+        const hz  = this._xToFreq(xi, W)
+        const bin = Math.min(Math.floor((hz / nyquist) * bins), bins - 1)
+        ctx.lineTo(xi, specToY(data[bin]))
+      }
+      ctx.strokeStyle = `rgba(${rgb},${strokeAlpha * op})`
+      ctx.lineWidth = lineW
+      ctx.lineJoin = 'round'
+      ctx.stroke()
+    }
+
+    // Pre-EQ ghost (complementary hue, drawn first so it's behind)
+    drawGhost(this._preSmoothed,  this._getComplementaryRGB(), 0.15, 0.30, 1.0)
+    // Post-EQ ghost (accent color, drawn on top)
+    drawGhost(this._postSmoothed, this._getAccentRGB(),        0.12, 0.25, 1.2)
+  }
+
+  // ── Spectrum RAF loop ─────────────────────────────────────────────────────
+
+  setPlaybackState(playing: boolean): void {
+    this._isPlayingAudio = playing
+    if (playing) this._startSpectrumLoop()
+  }
+
+  private _startSpectrumLoop(): void {
+    if (this._spectrumRafId !== null) return
+    this._spectrumRafId = requestAnimationFrame(this._spectrumRafLoop)
+  }
+
+  private _spectrumRafLoop = (): void => {
+    const target = this._isPlayingAudio ? 1 : 0
+    this._spectrumOpacity += (target - this._spectrumOpacity) * 0.04
+
+    if (this._spectrumOpacity > 0.01) this._updateSmoothedSpectrum()
+
+    this._drawEQCurve()
+
+    if (this._isPlayingAudio || this._spectrumOpacity > 0.01) {
+      this._spectrumRafId = requestAnimationFrame(this._spectrumRafLoop)
+    } else {
+      this._spectrumRafId = null
+    }
+  }
+
+  private _updateSmoothedSpectrum(): void {
+    const preA  = this.engine.analyserPreEQ
+    const postA = this.engine.analyserNode
+    if (!preA || !postA) return
+
+    const bins = preA.frequencyBinCount
+    if (!this._preSmoothed || this._spectrumBins !== bins) {
+      this._preSmoothed  = new Float32Array(bins)
+      this._postSmoothed = new Float32Array(bins)
+      this._spectrumBins = bins
+    }
+
+    const raw   = new Uint8Array(bins)
+    const alpha = this._SPECTRUM_ALPHA
+    const minDb = preA.minDecibels
+    const range = preA.maxDecibels - minDb
+
+    preA.getByteFrequencyData(raw)
+    for (let i = 0; i < bins; i++) {
+      const v = (raw[i] / 255) * range + minDb
+      this._preSmoothed![i] = alpha * this._preSmoothed![i] + (1 - alpha) * v
+    }
+
+    postA.getByteFrequencyData(raw)
+    for (let i = 0; i < bins; i++) {
+      const v = (raw[i] / 255) * range + minDb
+      this._postSmoothed![i] = alpha * this._postSmoothed![i] + (1 - alpha) * v
+    }
+  }
+
+  // Returns 180°-hue-rotated, slightly desaturated version of the accent colour.
+  private _getComplementaryRGB(): string {
+    const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim()
+    if (accent.startsWith('#')) {
+      const hex = accent.slice(1)
+      if (hex.length === 6) {
+        // Hex → linear [0,1] RGB
+        const r = parseInt(hex.slice(0, 2), 16) / 255
+        const g = parseInt(hex.slice(2, 4), 16) / 255
+        const b = parseInt(hex.slice(4, 6), 16) / 255
+        // RGB → HSL
+        const max = Math.max(r, g, b), min = Math.min(r, g, b), d = max - min
+        const l = (max + min) / 2
+        const s = d === 0 ? 0 : l > 0.5 ? d / (2 - max - min) : d / (max + min)
+        let h = 0
+        if (d !== 0) {
+          if (max === r)      h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+          else if (max === g) h = ((b - r) / d + 2) / 6
+          else                h = ((r - g) / d + 4) / 6
+        }
+        // Rotate hue 180°, desaturate slightly, normalize lightness
+        const ch = (h + 0.5) % 1
+        const cs = s * 0.8
+        const cl = Math.max(0.30, Math.min(0.70, l))
+        // HSL → RGB
+        const hue2rgb = (p: number, q: number, t: number) => {
+          const tt = ((t % 1) + 1) % 1
+          if (tt < 1/6) return p + (q - p) * 6 * tt
+          if (tt < 1/2) return q
+          if (tt < 2/3) return p + (q - p) * (2/3 - tt) * 6
+          return p
+        }
+        const q2 = cl < 0.5 ? cl * (1 + cs) : cl + cs - cl * cs
+        const p2 = 2 * cl - q2
+        const cr = Math.round(hue2rgb(p2, q2, ch + 1/3) * 255)
+        const cg = Math.round(hue2rgb(p2, q2, ch      ) * 255)
+        const cb = Math.round(hue2rgb(p2, q2, ch - 1/3) * 255)
+        return `${cr},${cg},${cb}`
+      }
+    }
+    return '0,200,255'  // cyan — complements Meridian lime green
   }
 
   // Reads the current --accent CSS variable to use the active theme colour.


### PR DESCRIPTION
Closes #88

## Summary

- **Ableton/Pro-Q style grid** — dB labels on both sides (±12, ±6, 0), frequency labels on X-axis (20 Hz → 20 kHz), dotted vertical frequency lines, heavier 0 dB centerline
- **Pre-EQ spectrum ghost** — filled curve in the complementary hue of the accent color showing raw input frequency content before the EQ chain
- **Post-EQ spectrum ghost** — filled curve in the accent color showing processed output; updates live as EQ nodes are dragged so you can see the EQ correction taking effect
- **Calm/fluid animation** — α = 0.88 exponential smoothing, ghosts fade in on play and fade out (~0.5 s) on pause

## Audio chain change

A second `AnalyserNode` is inserted as a parallel tap off `masterGainNode` (before the EQ chain). A silent GainNode (gain=0) keeps it active in the Web Audio rendering graph without audible output. No change to the main signal path.

## Files changed

| File | Change |
|------|--------|
| `src/audio/AudioEngine.ts` | `_analyserPreEQNode` field, wiring in `ensureContext()`, `get analyserPreEQ()` getter |
| `src/ui/EffectsController.ts` | `_drawGrid()`, `_drawSpectrumGhosts()`, `_spectrumRafLoop`, `_updateSmoothedSpectrum()`, `_getComplementaryRGB()`, `setPlaybackState()` |
| `src/ui/App.ts` | `setPlayingState()` calls `this.effects.setPlaybackState(playing)` |

## Test plan

- [ ] Grid lines and labels visible on EQ canvas before audio loads
- [ ] Ghost curves appear on play; pre-EQ (complementary color) and post-EQ (accent) are visually distinct
- [ ] Dragging an EQ node moves the post-EQ ghost in that frequency band; pre-EQ ghost is unaffected
- [ ] Ghost curves drift smoothly (calm/fluid) — not jittery or snappy
- [ ] Pause → ghosts fade out over ~0.5 s; resume → ghosts fade back in
- [ ] No regression on EQ node drag, Q scroll wheel, or slider sync
- [ ] `npm run build` passes with no type errors