### PR TITLE
fix: prevent orb chunk from failing to load on Cloudflare

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self'; frame-ancestors 'none'
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,14 @@
-// PRECACHE_ASSETS is replaced at build time by scripts/precache-sw.mjs.
-// It will contain the hashed JS/CSS bundle filenames from the Vite manifest
-// so they are cached at install time rather than only on first fetch.
+// PRECACHE_ASSETS and BUILD_ID are replaced at build time by
+// scripts/precache-sw.mjs. PRECACHE_ASSETS holds the hashed JS/CSS bundle
+// filenames from the Vite manifest so they are cached at install time rather
+// than only on first fetch. BUILD_ID is a per-build hash so the cache name is
+// unique to each deploy and old caches are evicted on activate.
 // Audio files are loaded via File.arrayBuffer() and never pass through here,
 // so no audio data ever enters the cache.
 const PRECACHE_ASSETS = []
+const BUILD_ID = 'dev'
 
-const CACHE = 'slo-fi-v2'
+const CACHE = `slo-fi-${BUILD_ID}`
 const SHELL = ['/', '/index.html', '/manifest.json', '/favicon.svg']
 
 self.addEventListener('install', (e) => {
@@ -24,22 +27,66 @@ self.addEventListener('activate', (e) => {
   )
 })
 
+// Content-hashed, immutable build output. The filename changes whenever the
+// content changes, so cache-first is both safe and fast for these.
+function isHashedAsset(url) {
+  return url.pathname.startsWith('/assets/')
+}
+
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return
-  // Serve from cache first. On a miss, fetch from the network and cache the
-  // response so any assets not precached are available on the next offline load.
-  // Audio files are loaded via File.arrayBuffer() and never pass through here,
-  // so no audio data ever enters the cache.
-  e.respondWith(
-    caches.match(e.request).then((cached) => {
-      if (cached) return cached
-      return fetch(e.request).then((res) => {
-        if (res.ok && e.request.url.startsWith(self.location.origin)) {
+  const url = new URL(e.request.url)
+  if (url.origin !== self.location.origin) return
+
+  // Navigations and the HTML shell: network-first. A redeployed index.html
+  // references fresh chunk hashes, so it must win over any cached copy when
+  // online — this is what prevents an old page from importing a chunk hash
+  // that the current deploy no longer serves. Falls back to cache offline.
+  if (e.request.mode === 'navigate' || url.pathname === '/index.html' || url.pathname === '/') {
+    e.respondWith(
+      fetch(e.request)
+        .then((res) => {
           const clone = res.clone()
           caches.open(CACHE).then((c) => c.put(e.request, clone))
-        }
-        return res
+          return res
+        })
+        .catch(() => caches.match(e.request).then((c) => c || caches.match('/index.html')))
+    )
+    return
+  }
+
+  // Immutable hashed assets: cache-first.
+  if (isHashedAsset(url)) {
+    e.respondWith(
+      caches.match(e.request).then((cached) => {
+        if (cached) return cached
+        return fetch(e.request).then((res) => {
+          if (res.ok) {
+            const clone = res.clone()
+            caches.open(CACHE).then((c) => c.put(e.request, clone))
+          }
+          return res
+        })
       })
+    )
+    return
+  }
+
+  // Everything else (icons, manifest.json, worklets, etc.): stale-while-
+  // revalidate — serve the cached copy immediately, refresh it in the
+  // background so the next load is current.
+  e.respondWith(
+    caches.match(e.request).then((cached) => {
+      const network = fetch(e.request)
+        .then((res) => {
+          if (res.ok) {
+            const clone = res.clone()
+            caches.open(CACHE).then((c) => c.put(e.request, clone))
+          }
+          return res
+        })
+        .catch(() => cached)
+      return cached || network
     })
   )
 })

--- a/scripts/precache-sw.mjs
+++ b/scripts/precache-sw.mjs
@@ -1,8 +1,11 @@
 // Post-build script: reads the Vite asset manifest and injects hashed
 // JS/CSS filenames into the PRECACHE_ASSETS array in dist/sw.js so the
-// service worker precaches all built bundles at install time.
+// service worker precaches all built bundles at install time. Also injects a
+// per-build BUILD_ID (a short hash of the manifest) so the cache name changes
+// every deploy and the activate handler evicts the previous build's cache.
 // Run automatically via: npm run build
 import fs from 'fs'
+import crypto from 'crypto'
 
 const manifestPath = 'dist/.vite/manifest.json'
 const swPath = 'dist/sw.js'
@@ -12,7 +15,8 @@ if (!fs.existsSync(manifestPath)) {
   process.exit(0)
 }
 
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+const manifestRaw = fs.readFileSync(manifestPath, 'utf-8')
+const manifest = JSON.parse(manifestRaw)
 
 const assets = Object.values(manifest).flatMap((entry) => {
   const files = []
@@ -21,10 +25,19 @@ const assets = Object.values(manifest).flatMap((entry) => {
   return files
 })
 
+// Deterministic per-build id: any change to a built file changes its hashed
+// filename, which changes the manifest, which changes this id.
+const buildId = crypto.createHash('sha256').update(manifestRaw).digest('hex').slice(0, 10)
+
 let sw = fs.readFileSync(swPath, 'utf-8')
-sw = sw.replace(
-  'const PRECACHE_ASSETS = []',
-  `const PRECACHE_ASSETS = ${JSON.stringify(assets)}`,
-)
+sw = sw
+  .replace(
+    'const PRECACHE_ASSETS = []',
+    `const PRECACHE_ASSETS = ${JSON.stringify(assets)}`,
+  )
+  .replace(
+    "const BUILD_ID = 'dev'",
+    `const BUILD_ID = '${buildId}'`,
+  )
 fs.writeFileSync(swPath, sw)
-console.log(`precache-sw: injected ${assets.length} asset(s) into ${swPath}`)
+console.log(`precache-sw: injected ${assets.length} asset(s), build ${buildId}, into ${swPath}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,26 @@ import './styles/main.css'
 import { App } from './ui/App'
 import { SplashController } from './ui/SplashController'
 
+// A dynamically-imported chunk (e.g. the 3D orb) can fail to load when a
+// client is running an index.html from a previous deploy that references chunk
+// hashes the current deploy no longer serves. Vite fires `vite:preloadError`
+// in that case; reload once to fetch the current index.html and chunks. The
+// sessionStorage guard prevents a reload loop when the server is genuinely
+// unreachable.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+  if (!sessionStorage.getItem('reloadedAfterPreloadError')) {
+    sessionStorage.setItem('reloadedAfterPreloadError', '1')
+    window.location.reload()
+  }
+})
+
+// Clear the guard shortly after a healthy load so a future genuine stale-chunk
+// failure can still trigger one self-healing reload.
+window.addEventListener('load', () => {
+  setTimeout(() => sessionStorage.removeItem('reloadedAfterPreloadError'), 5000)
+})
+
 new SplashController()
 new App()
 

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -951,7 +951,15 @@ export class App {
 
     if (!this.sphere && this.engine.analyserNode) {
       try {
-        const { AnomalySphere } = await import('./AnomalySphere')
+        let mod: typeof import('./AnomalySphere')
+        try {
+          mod = await import('./AnomalySphere')
+        } catch {
+          // One retry: covers a mid-session service-worker cache swap or a
+          // transient network blip fetching the code-split orb chunk.
+          mod = await import('./AnomalySphere')
+        }
+        const { AnomalySphere } = mod
         this.sphere = new AnomalySphere(
           document.getElementById('anomaly') as HTMLElement,
           this.engine.analyserNode,
@@ -987,7 +995,18 @@ export class App {
         this.sphere.setParticleCount(parseInt(this.particleCountSlider.value))
         this.sphere.setStarBrightness(parseInt(this.starsSlider.value) / 100)
       } catch (sphereErr) {
-        console.error('3D sphere unavailable (WebGL may not be supported):', sphereErr)
+        // Distinguish a failed chunk load (stale cache / network) from genuine
+        // WebGL-unsupported so the cause is diagnosable rather than ambiguous.
+        const message = String((sphereErr as Error)?.message ?? sphereErr)
+        const isChunkLoadFailure =
+          sphereErr instanceof TypeError &&
+          /dynamically imported module|Failed to fetch|error loading dynamically|importing a module script failed/i.test(message)
+        console.error(
+          isChunkLoadFailure
+            ? '3D sphere chunk failed to load (stale cache or network issue) — a reload may resolve this:'
+            : '3D sphere unavailable (WebGL may not be supported):',
+          sphereErr,
+        )
       }
     }
   }


### PR DESCRIPTION
## Problem

The homepage orb (\`AnomalySphere\`, a dynamically-imported Three.js code-split chunk) renders in \`vite\` dev but **silently disappears** when served through Cloudflare (\`slofi.live\`, \`*.workers.dev\`). Confirmed on both \`v3\` and \`main\`.

## Root cause (reproduced locally via \`wrangler dev\`)

Two prod-only mechanisms — neither active in Vite dev — combine:

1. **Permanent SW staleness.** \`public/sw.js\` used a *static* cache name (\`slo-fi-v2\`) and served \`index.html\` **cache-first**. The \`activate\` purge only deletes caches *not* named \`slo-fi-v2\`, so it never fired across redeploys. Repeat visitors kept running an old \`index.html\` pointing at chunk hashes a later deploy had removed.
2. **SPA-fallback MIME trap.** The stale page's \`import('./AnomalySphere-<oldHash>.js')\` 404s; \`not_found_handling: single-page-application\` rewrites the 404 into a \`200 text/html\` \`index.html\`. With \`X-Content-Type-Options: nosniff\`, the browser hard-refuses to run HTML as a module → the import throws → caught by a bare \`try/catch\` that only \`console.error\`s → orb never mounts.

Verified over HTTP against \`wrangler dev\`: a request for a missing \`/assets/*.js\` returns \`200 OK\` + \`Content-Type: text/html\`.

The strict CSP in \`_headers\` was audited and ruled out (nothing in the orb/WebGPU/worklet paths uses eval/wasm/blob workers).

## Changes

- **\`public/sw.js\`** — versioned cache name (\`slo-fi-\${BUILD_ID}\`); \`activate\` now evicts prior deploys; **network-first** for navigations/\`index.html\` (fresh chunk hashes always win when online), cache-first only for immutable \`/assets/*\`, stale-while-revalidate for the rest.
- **\`scripts/precache-sw.mjs\`** — injects a per-build \`BUILD_ID\` (short sha256 of the Vite manifest) alongside the existing precache list.
- **\`src/main.ts\`** — one-time \`window.location.reload()\` on \`vite:preloadError\`, guarded by \`sessionStorage\` to avoid loops.
- **\`src/ui/App.ts\`** — retry the orb import once; log distinguishes chunk-load failure from WebGL-unsupported.
- **\`public/_headers\`** — explicit \`worker-src 'self'\` (hardening).

## Verification

- \`npm run lint\` (tsc) clean; \`npm run build\` succeeds and injects \`BUILD_ID\` + orb chunk into \`dist/sw.js\`.
- \`wrangler dev\`: index served with corrected CSP; real orb chunk serves as \`text/javascript\`; missing chunk reproduces the \`200 text/html\` trap that this change routes around.

## Rollout note

Existing clients still holding the *old* service worker will get the fix on their **next** load: the new SW installs and claims, and from the following navigation on, network-first \`index.html\` keeps them current. First-time/new visitors are correct immediately.

## Optional follow-up (not in this PR)

The SPA-fallback MIME trap itself still exists at the edge (a genuinely missing chunk returns HTML-as-JS). A thin Worker in front of the assets binding that 404s honestly for \`/assets/*\` would close it as defense-in-depth. Left out here to avoid changing deploy shape; this PR removes the *path* that reaches the trap.