### PR TITLE
fix: prevent orb chunk from failing to load on Cloudflare

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self'; frame-ancestors 'none'
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,14 @@
-// PRECACHE_ASSETS is replaced at build time by scripts/precache-sw.mjs.
-// It will contain the hashed JS/CSS bundle filenames from the Vite manifest
-// so they are cached at install time rather than only on first fetch.
+// PRECACHE_ASSETS and BUILD_ID are replaced at build time by
+// scripts/precache-sw.mjs. PRECACHE_ASSETS holds the hashed JS/CSS bundle
+// filenames from the Vite manifest so they are cached at install time rather
+// than only on first fetch. BUILD_ID is a per-build hash so the cache name is
+// unique to each deploy and old caches are evicted on activate.
 // Audio files are loaded via File.arrayBuffer() and never pass through here,
 // so no audio data ever enters the cache.
 const PRECACHE_ASSETS = []
+const BUILD_ID = 'dev'
 
-const CACHE = 'slo-fi-v2'
+const CACHE = `slo-fi-${BUILD_ID}`
 const SHELL = ['/', '/index.html', '/manifest.json', '/favicon.svg']
 
 self.addEventListener('install', (e) => {
@@ -24,22 +27,66 @@ self.addEventListener('activate', (e) => {
   )
 })
 
+// Content-hashed, immutable build output. The filename changes whenever the
+// content changes, so cache-first is both safe and fast for these.
+function isHashedAsset(url) {
+  return url.pathname.startsWith('/assets/')
+}
+
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return
-  // Serve from cache first. On a miss, fetch from the network and cache the
-  // response so any assets not precached are available on the next offline load.
-  // Audio files are loaded via File.arrayBuffer() and never pass through here,
-  // so no audio data ever enters the cache.
-  e.respondWith(
-    caches.match(e.request).then((cached) => {
-      if (cached) return cached
-      return fetch(e.request).then((res) => {
-        if (res.ok && e.request.url.startsWith(self.location.origin)) {
+  const url = new URL(e.request.url)
+  if (url.origin !== self.location.origin) return
+
+  // Navigations and the HTML shell: network-first. A redeployed index.html
+  // references fresh chunk hashes, so it must win over any cached copy when
+  // online — this is what prevents an old page from importing a chunk hash
+  // that the current deploy no longer serves. Falls back to cache offline.
+  if (e.request.mode === 'navigate' || url.pathname === '/index.html' || url.pathname === '/') {
+    e.respondWith(
+      fetch(e.request)
+        .then((res) => {
           const clone = res.clone()
           caches.open(CACHE).then((c) => c.put(e.request, clone))
-        }
-        return res
+          return res
+        })
+        .catch(() => caches.match(e.request).then((c) => c || caches.match('/index.html')))
+    )
+    return
+  }
+
+  // Immutable hashed assets: cache-first.
+  if (isHashedAsset(url)) {
+    e.respondWith(
+      caches.match(e.request).then((cached) => {
+        if (cached) return cached
+        return fetch(e.request).then((res) => {
+          if (res.ok) {
+            const clone = res.clone()
+            caches.open(CACHE).then((c) => c.put(e.request, clone))
+          }
+          return res
+        })
       })
+    )
+    return
+  }
+
+  // Everything else (icons, manifest.json, worklets, etc.): stale-while-
+  // revalidate — serve the cached copy immediately, refresh it in the
+  // background so the next load is current.
+  e.respondWith(
+    caches.match(e.request).then((cached) => {
+      const network = fetch(e.request)
+        .then((res) => {
+          if (res.ok) {
+            const clone = res.clone()
+            caches.open(CACHE).then((c) => c.put(e.request, clone))
+          }
+          return res
+        })
+        .catch(() => cached)
+      return cached || network
     })
   )
 })

--- a/scripts/precache-sw.mjs
+++ b/scripts/precache-sw.mjs
@@ -1,8 +1,11 @@
 // Post-build script: reads the Vite asset manifest and injects hashed
 // JS/CSS filenames into the PRECACHE_ASSETS array in dist/sw.js so the
-// service worker precaches all built bundles at install time.
+// service worker precaches all built bundles at install time. Also injects a
+// per-build BUILD_ID (a short hash of the manifest) so the cache name changes
+// every deploy and the activate handler evicts the previous build's cache.
 // Run automatically via: npm run build
 import fs from 'fs'
+import crypto from 'crypto'
 
 const manifestPath = 'dist/.vite/manifest.json'
 const swPath = 'dist/sw.js'
@@ -12,7 +15,8 @@ if (!fs.existsSync(manifestPath)) {
   process.exit(0)
 }
 
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+const manifestRaw = fs.readFileSync(manifestPath, 'utf-8')
+const manifest = JSON.parse(manifestRaw)
 
 const assets = Object.values(manifest).flatMap((entry) => {
   const files = []
@@ -21,10 +25,19 @@ const assets = Object.values(manifest).flatMap((entry) => {
   return files
 })
 
+// Deterministic per-build id: any change to a built file changes its hashed
+// filename, which changes the manifest, which changes this id.
+const buildId = crypto.createHash('sha256').update(manifestRaw).digest('hex').slice(0, 10)
+
 let sw = fs.readFileSync(swPath, 'utf-8')
-sw = sw.replace(
-  'const PRECACHE_ASSETS = []',
-  `const PRECACHE_ASSETS = ${JSON.stringify(assets)}`,
-)
+sw = sw
+  .replace(
+    'const PRECACHE_ASSETS = []',
+    `const PRECACHE_ASSETS = ${JSON.stringify(assets)}`,
+  )
+  .replace(
+    "const BUILD_ID = 'dev'",
+    `const BUILD_ID = '${buildId}'`,
+  )
 fs.writeFileSync(swPath, sw)
-console.log(`precache-sw: injected ${assets.length} asset(s) into ${swPath}`)
+console.log(`precache-sw: injected ${assets.length} asset(s), build ${buildId}, into ${swPath}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,26 @@
 import './styles/main.css'
 import { App } from './ui/App'
 
+// A dynamically-imported chunk (e.g. the 3D orb) can fail to load when a
+// client is running an index.html from a previous deploy that references chunk
+// hashes the current deploy no longer serves. Vite fires `vite:preloadError`
+// in that case; reload once to fetch the current index.html and chunks. The
+// sessionStorage guard prevents a reload loop when the server is genuinely
+// unreachable.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+  if (!sessionStorage.getItem('reloadedAfterPreloadError')) {
+    sessionStorage.setItem('reloadedAfterPreloadError', '1')
+    window.location.reload()
+  }
+})
+
+// Clear the guard shortly after a healthy load so a future genuine stale-chunk
+// failure can still trigger one self-healing reload.
+window.addEventListener('load', () => {
+  setTimeout(() => sessionStorage.removeItem('reloadedAfterPreloadError'), 5000)
+})
+
 new App()
 
 const loader = document.getElementById('page-loader')

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -906,7 +906,15 @@ export class App {
 
     if (!this.sphere && this.engine.analyserNode) {
       try {
-        const { AnomalySphere } = await import('./AnomalySphere')
+        let mod: typeof import('./AnomalySphere')
+        try {
+          mod = await import('./AnomalySphere')
+        } catch {
+          // One retry: covers a mid-session service-worker cache swap or a
+          // transient network blip fetching the code-split orb chunk.
+          mod = await import('./AnomalySphere')
+        }
+        const { AnomalySphere } = mod
         this.sphere = new AnomalySphere(
           document.getElementById('anomaly') as HTMLElement,
           this.engine.analyserNode,
@@ -942,7 +950,18 @@ export class App {
         this.sphere.setParticleCount(parseInt(this.particleCountSlider.value))
         this.sphere.setStarBrightness(parseInt(this.starsSlider.value) / 100)
       } catch (sphereErr) {
-        console.error('3D sphere unavailable (WebGL may not be supported):', sphereErr)
+        // Distinguish a failed chunk load (stale cache / network) from genuine
+        // WebGL-unsupported so the cause is diagnosable rather than ambiguous.
+        const message = String((sphereErr as Error)?.message ?? sphereErr)
+        const isChunkLoadFailure =
+          sphereErr instanceof TypeError &&
+          /dynamically imported module|Failed to fetch|error loading dynamically|importing a module script failed/i.test(message)
+        console.error(
+          isChunkLoadFailure
+            ? '3D sphere chunk failed to load (stale cache or network issue) — a reload may resolve this:'
+            : '3D sphere unavailable (WebGL may not be supported):',
+          sphereErr,
+        )
       }
     }
   }


### PR DESCRIPTION
Backport of #93 to \`main\` (the reported orb-disappears-on-Cloudflare bug affects \`main\` as well as \`v3\`).

## Root cause (reproduced locally via \`wrangler dev\`)

The orb (\`AnomalySphere\`) is a dynamically-imported code-split chunk. The service worker used a *static* cache name and served \`index.html\` cache-first, so repeat visitors kept running a stale \`index.html\` referencing chunk hashes a later deploy had removed. The missing chunk request was rewritten by \`not_found_handling: single-page-application\` into a \`200 text/html\` response, which fails the module MIME check (\`nosniff\`) and silently disables the orb. Works in Vite dev because neither the SW nor \`_headers\` is active there.

## Changes (identical to #93)

- **\`public/sw.js\`** — per-build versioned cache name; \`activate\` evicts prior deploys; network-first for navigations/\`index.html\`, cache-first for immutable \`/assets/*\`, stale-while-revalidate for the rest.
- **\`scripts/precache-sw.mjs\`** — injects a \`BUILD_ID\` (short sha256 of the Vite manifest).
- **\`src/main.ts\`** — one-time reload on \`vite:preloadError\` (sessionStorage-guarded). Adapted to this branch's bootstrap (no \`SplashController\`).
- **\`src/ui/App.ts\`** — retry the orb import once; log distinguishes chunk-load failure from WebGL-unsupported.
- **\`public/_headers\`** — explicit \`worker-src 'self'\`.

## Verification

\`npm run lint\` clean; \`npm run build\` succeeds and injects \`BUILD_ID\` + the orb chunk into \`dist/sw.js\`.

## Rollout note

Clients still holding the old service worker pick up the fix on their next load (new SW installs + claims; network-first \`index.html\` keeps them current thereafter). New visitors are correct immediately.