### PR TITLE
fix: orb renders blank on WebGPU-capable browsers (disable half-finished WebGPU upgrade)

### DIFF
--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -908,10 +908,16 @@ export class AnomalySphere {
     this.loop()
     requestAnimationFrame(() => this.resize())
 
-    // Fire-and-forget: attempt to upgrade from WebGLRenderer to WebGPURenderer.
-    // The sphere keeps rendering on WebGL2 immediately; if WebGPU is available
-    // the renderer swaps in the background before the first user interaction.
-    this._tryWebGPUUpgrade()
+    // WebGPU upgrade is gated OFF. _tryWebGPUUpgrade() swaps in a WebGPURenderer
+    // but only the sphere material is ported to TSL — the particle cloud, star
+    // field, and post-processing passes remain raw GLSL (RawShaderMaterial/
+    // ShaderMaterial), which the WebGPU node pipeline cannot render
+    // ("THREE.NodeMaterial: Material ... is not compatible"). On any WebGPU-
+    // capable browser (e.g. desktop Chrome) that makes the whole orb render
+    // blank. Stay on the working WebGLRenderer until every material and pass is
+    // ported to TSL, then flip this flag back to true.
+    const ENABLE_WEBGPU_UPGRADE = false
+    if (ENABLE_WEBGPU_UPGRADE) this._tryWebGPUUpgrade()
   }
 
   // Attempts a progressive upgrade to WebGPURenderer.


### PR DESCRIPTION
## The actual root cause of the disappearing orb

Confirmed **live via the browser console** on slofi.live (real Chrome, WebGPU enabled). After the earlier service-worker/chunk-loading fix (#93) let the orb chunk load at all, the orb was *still* blank, and the console showed why:

\`\`\`
[AnomalySphere] Upgraded to WebGPU renderer with TSL node materials
THREE.NodeMaterial: Material "RawShaderMaterial" is not compatible.
THREE.NodeMaterial: Material "ShaderMaterial" is not compatible.   ← every frame
\`\`\`

\`_tryWebGPUUpgrade()\` swaps the working \`WebGLRenderer\` for a \`WebGPURenderer\`, but only the **sphere** material was ported to TSL. The **particle cloud, star field, and post-processing passes** (UnrealBloom, grain, glitch, output) remain raw GLSL (\`RawShaderMaterial\`/\`ShaderMaterial\`), which the WebGPU node pipeline **cannot render**. Every render call throws "not compatible" and draws nothing — so on any WebGPU-capable browser (desktop Chrome) the orb initializes on WebGL, then goes blank the instant the upgrade completes.

This is why it "worked in dev but not hosted": it actually breaks wherever the WebGPU upgrade succeeds; the old cached/prior build simply masked it until now.

## Fix

Gate the upgrade off behind \`ENABLE_WEBGPU_UPGRADE = false\` so the orb stays on the fully-working \`WebGLRenderer\`. One-line to flip back on once every material and pass is ported to TSL.

## Verification

- \`npm run lint\` (tsc) clean; \`npm run build\` succeeds.
- The console errors that caused the blank orb originate solely from the WebGPU render path; removing the swap leaves the WebGL path that renders the orb correctly. Final confirmation is a live reload on deploy.

## Note

Separately, Cloudflare's analytics \`beacon.min.js\` + its inline script are blocked by the CSP (\`script-src 'self'\`) — harmless (no analytics), not related to the orb. Can be addressed separately if you want CF Web Analytics working.