### PR TITLE
fix: orb renders blank on WebGPU-capable browsers (disable half-finished WebGPU upgrade)

### DIFF
--- a/src/ui/AnomalySphere.ts
+++ b/src/ui/AnomalySphere.ts
@@ -908,10 +908,16 @@ export class AnomalySphere {
     this.loop()
     requestAnimationFrame(() => this.resize())
 
-    // Fire-and-forget: attempt to upgrade from WebGLRenderer to WebGPURenderer.
-    // The sphere keeps rendering on WebGL2 immediately; if WebGPU is available
-    // the renderer swaps in the background before the first user interaction.
-    this._tryWebGPUUpgrade()
+    // WebGPU upgrade is gated OFF. _tryWebGPUUpgrade() swaps in a WebGPURenderer
+    // but only the sphere material is ported to TSL — the particle cloud, star
+    // field, and post-processing passes remain raw GLSL (RawShaderMaterial/
+    // ShaderMaterial), which the WebGPU node pipeline cannot render
+    // ("THREE.NodeMaterial: Material ... is not compatible"). On any WebGPU-
+    // capable browser (e.g. desktop Chrome) that makes the whole orb render
+    // blank. Stay on the working WebGLRenderer until every material and pass is
+    // ported to TSL, then flip this flag back to true.
+    const ENABLE_WEBGPU_UPGRADE = false
+    if (ENABLE_WEBGPU_UPGRADE) this._tryWebGPUUpgrade()
   }
 
   // Attempts a progressive upgrade to WebGPURenderer.


### PR DESCRIPTION
Backport of #95 to \`main\`.

## Root cause (confirmed live via browser console)

\`_tryWebGPUUpgrade()\` swaps the working \`WebGLRenderer\` for a \`WebGPURenderer\`, but only the sphere material is ported to TSL. The particle cloud, star field, and post-processing passes stay raw GLSL (\`RawShaderMaterial\`/\`ShaderMaterial\`), which the WebGPU node pipeline cannot render:

\`\`\`
THREE.NodeMaterial: Material "RawShaderMaterial" is not compatible.
THREE.NodeMaterial: Material "ShaderMaterial" is not compatible.
\`\`\`

Result: the orb goes blank the moment the upgrade completes, on any WebGPU-capable browser (desktop Chrome).

## Fix

Gate the upgrade behind \`ENABLE_WEBGPU_UPGRADE = false\`; the orb stays on the working \`WebGLRenderer\`. Restore once all materials/passes are ported to TSL.

\`npm run lint\` + \`npm run build\` clean.