### PR TITLE
ci(lighthouse): run 3x and assert on median to stop threshold flakiness

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,5 +14,8 @@ jobs:
       - uses: treosh/lighthouse-ci-action@v11
         with:
           configPath: ./lighthouserc.json
+          # Run 3 times and assert on the median (see lighthouserc.json) so a
+          # single noisy run near the 0.90 budget can't fail PRs at random.
+          runs: 3
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,14 +2,15 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:performance":   ["error", { "minScore": 0.9 }],
-        "categories:accessibility": ["error", { "minScore": 0.9 }],
-        "categories:best-practices":["error", { "minScore": 0.9 }],
-        "categories:pwa":           ["error", { "minScore": 0.9 }]
+        "categories:performance":   ["error", { "minScore": 0.9, "aggregationMethod": "median" }],
+        "categories:accessibility": ["error", { "minScore": 0.9, "aggregationMethod": "median" }],
+        "categories:best-practices":["error", { "minScore": 0.9, "aggregationMethod": "median" }],
+        "categories:pwa":           ["error", { "minScore": 0.9, "aggregationMethod": "median" }]
       }
     },
     "collect": {
-      "staticDistDir": "./dist"
+      "staticDistDir": "./dist",
+      "numberOfRuns": 3
     }
   }
 }


### PR DESCRIPTION
## Why
The Lighthouse **performance** budget (`>= 0.90`) is flaky on v3. The app's Three.js/WebGPU bundle scores right at the edge, and the check runs Lighthouse **once** (`runs: 1`), so the same commit scores 0.90+ on one run and 0.85 on another — failing PRs at random (e.g. an identical waveform fix passed on the `main` backport but failed twice on the v3 PR #98). It's not caused by the PRs it fails.

## Change
- `.github/workflows/lighthouse.yml`: pass `runs: 3` to the action.
- `lighthouserc.json`: `collect.numberOfRuns: 3` and `aggregationMethod: "median"` on each category assertion.

Keeps the **0.90 bar unchanged** — just asserts on the median of 3 runs instead of a single noisy sample, so genuine regressions still fail while single-run variance doesn't.

## Note
This PR's own Lighthouse check exercises the new 3-run/median config (same-repo PRs use the head branch's workflow).