### PR TITLE
fix(ci): remove impossible Lighthouse PWA category assertion

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,8 +4,7 @@
       "assertions": {
         "categories:performance":   ["error", { "minScore": 0.9, "aggregationMethod": "median" }],
         "categories:accessibility": ["error", { "minScore": 0.9, "aggregationMethod": "median" }],
-        "categories:best-practices":["error", { "minScore": 0.9, "aggregationMethod": "median" }],
-        "categories:pwa":           ["error", { "minScore": 0.9, "aggregationMethod": "median" }]
+        "categories:best-practices":["error", { "minScore": 0.9, "aggregationMethod": "median" }]
       }
     },
     "collect": {


### PR DESCRIPTION
## Summary
Removes the `categories:pwa` budget from `lighthouserc.json`. Lighthouse 12+ dropped the standalone scored PWA category (it's now a set of unscored informative audits), so this assertion never runs (`auditRan: 0` across all 3 runs) and will break the Lighthouse CI gate once `treosh/lighthouse-ci-action` upgrades past Lighthouse 11.

The performance, accessibility, and best-practices budgets are unchanged.

## Test plan
- [x] `lighthouserc.json` still valid JSON
- [x] Lighthouse CI workflow passes on this PR