### PR TITLE
fix(audio): normalize BPM autocorrelation by overlap length

### DIFF
--- a/src/audio/BpmDetector.ts
+++ b/src/audio/BpmDetector.ts
@@ -56,9 +56,13 @@ export function detectBpm(buffer: AudioBuffer): number {
   let bestLag = lagMin
   let bestCorr = -Infinity
   for (let lag = lagMin; lag <= lagMax; lag++) {
-    let corr = 0
     const limit = numFrames - lag
+    let corr = 0
     for (let f = 0; f < limit; f++) corr += onset[f] * onset[f + lag]
+
+    // Normalize by the number of overlapping frames. Without this, shorter
+    // lags accumulate more products and are biased toward higher BPM values.
+    corr /= limit
     if (corr > bestCorr) { bestCorr = corr; bestLag = lag }
   }
 


### PR DESCRIPTION
## Summary
`detectBpm()` in `src/audio/BpmDetector.ts` summed onset autocorrelation products per lag without dividing by the overlap window size (`numFrames - lag`). Shorter lags accumulate more product terms purely by construction, which biased peak selection toward higher BPM values regardless of the actual track tempo.

Fix: divide each lag's correlation sum by its overlap length (`limit`) before comparing against the running best correlation.

## Test plan
- [x] `npm run lint` (tsc --noEmit) passes
- [x] `npm run build` passes
- [ ] Spot-check detected BPM against a few known-tempo tracks